### PR TITLE
Detail page reacts to errors when fetching subjects

### DIFF
--- a/globus_portal_framework/templates/detail-base.html
+++ b/globus_portal_framework/templates/detail-base.html
@@ -49,14 +49,30 @@
         </div>
 
         <div class="card-body">
+            {% if error %}
+            {% block detail_body_error %}
+            <div class="container mt-3">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="alert alert-warning" role="alert">
+                            <h3>Error Fetching Search Record</h3>
+                            <p>{{ error }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endblock %}
+            {% else %}
             <ul class="nav nav-tabs">
             {% index_template "components/detail-nav.html" as it_detail_nav %}
             {% include it_detail_nav %}
             </ul>
+
             <div class="container">
                 {%block detail_body %}
                 {%endblock%}
             </div>
+            {% endif %}
         </div>
     </div>
 


### PR DESCRIPTION
These changes also don't attempt to load the NAV when there are errors,
which previously caused Django to fail in reversing URLs due to the info
required from the subject to build the URL not being present.

<img width="1280" alt="screen shot 2019-02-22 at 11 34 11 am" src="https://user-images.githubusercontent.com/865553/53268825-fa60f600-369b-11e9-921e-c5b56a95e605.png">
