### PR TITLE
[Depends on #68] Built in 404 and 500

### DIFF
--- a/globus_portal_framework/templates/404.html
+++ b/globus_portal_framework/templates/404.html
@@ -1,0 +1,16 @@
+{%extends "base.html"%}
+
+{%block title%}404 Not Found{%endblock%}
+
+{%block body%}
+<div class="container mt-3">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="alert alert-info" role="alert">
+              <h3>Woops!</h3>
+              <p>This page doesn't exist. You can return to the portal by clicking the title.</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/globus_portal_framework/templates/500.html
+++ b/globus_portal_framework/templates/500.html
@@ -1,0 +1,16 @@
+{%extends "base.html"%}
+
+{%block title%}Server Error{%endblock%}
+
+{%block body%}
+<div class="container mt-3">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="alert alert-info" role="alert">
+              <h3>Ouch!</h3>
+              <p>That's an error. Sorry about that, let us know and we'll get this fixed!</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/globus_portal_framework/templatetags/index_template.py
+++ b/globus_portal_framework/templatetags/index_template.py
@@ -50,7 +50,8 @@ class IndexTemplateNode(template.Node):
     def render(self, context):
         template = self.template_name
         try:
-            index = context['globus_portal_framework'].get('index', None)
+            index = context.get('globus_portal_framework', {}).get('index',
+                                                                   None)
             if index is not None:
                 template = get_template(index, self.template_name)
                 if template != self.template_name:

--- a/globus_portal_framework/tests/test_view_errors.py
+++ b/globus_portal_framework/tests/test_view_errors.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+from django.urls import path
+
+from globus_portal_framework.urls import urlpatterns
+from globus_portal_framework.views import handler500, handler404
+
+
+urlpatterns += [
+    path('not-a-real-page', handler404),
+    path('exception-view/', handler500)
+]
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class CustomErrorHandlerTests(SimpleTestCase):
+
+    @mock.patch('globus_portal_framework.views.log', mock.Mock())
+    def test_404_handler(self):
+        response = self.client.get('/not-a-real-page/')
+        # Make assertions on the response here. For example:
+        self.assertContains(response, "This page doesn't exist.",
+                            status_code=404)
+
+    def test_500_handler(self):
+        response = self.client.get('/exception-view/')
+        # Make assertions on the response here. For example:
+        self.assertContains(response, "That's an error.", status_code=500)
+
+    @mock.patch('globus_portal_framework.views.log')
+    def test_500_logs_exception(self, log):
+        handler500(self.client.get('/exception-view/'), Exception())
+        self.assertTrue(log.exception.called)

--- a/globus_portal_framework/urls.py
+++ b/globus_portal_framework/urls.py
@@ -69,3 +69,7 @@ if getattr(settings, 'GLOBUS_PORTAL_FRAMEWORK_DEVELOPMENT_APP', False):
         path('', include('social_django.urls', namespace='social')),
         path('', include('globus_portal_framework.urls_debugging'))
     ])
+
+
+handler404 = 'globus_portal_framework.views.handler404'
+handler500 = 'globus_portal_framework.views.handler500'

--- a/globus_portal_framework/views.py
+++ b/globus_portal_framework/views.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from json import dumps
 import globus_sdk
 from django.contrib import messages
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, render_to_response
 from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import logout as django_logout
@@ -225,3 +225,19 @@ def logout(request, next='/'):
         revoke_globus_tokens(request.user)
         django_logout(request)
     return redirect(request.GET.get('next', next))
+
+
+def handler404(request, exception=None, template_name='404.html'):
+    if exception:
+        log.debug(exception)
+    response = render_to_response(template_name)
+    response.status_code = 404
+    return response
+
+
+def handler500(request, exception=None, template_name='500.html'):
+    if exception:
+        log.exception(exception)
+    response = render_to_response(template_name)
+    response.status_code = 500
+    return response


### PR DESCRIPTION
Adds a nicer error page when one doesn't exist or the server 500s: 
<img width="1279" alt="screen shot 2019-02-26 at 11 59 51 am" src="https://user-images.githubusercontent.com/865553/53442674-b41ed600-39be-11e9-8502-cefdcba2015f.png">
