### PR TITLE
Changed search debugging utilities to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Then wire up the search portal in your `myproject/urls.py`
 
     urlpatterns = [
         path('', include('globus_portal_framework.urls')),
+        path('', include('globus_portal_framework.urls_debugging')),
     ]
 ```
 

--- a/globus_portal_framework/context_processors.py
+++ b/globus_portal_framework/context_processors.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.urls import resolve
+from django.urls import resolve, reverse, NoReverseMatch
 from globus_portal_framework import get_index, IndexNotFound
 
 
@@ -14,6 +14,13 @@ def globals(request):
         index_data = get_index(index)
     except IndexNotFound:
         index_data = {}
+
+    try:
+        reverse('search-debug', args=[index])
+        search_debugging_enabled = True
+    except NoReverseMatch:
+        search_debugging_enabled = False
+
     return {'globus_portal_framework': {
                 'project_title': getattr(settings, 'PROJECT_TITLE',
                                          'Globus Portal Framework'),
@@ -21,5 +28,6 @@ def globals(request):
                 'transfer_enabled': auth_enabled and transfer_scope_set,
                 'index_data': index_data,
                 'index': index,
+                'search_debugging_enabled': search_debugging_enabled,
                 }
             }

--- a/globus_portal_framework/templates/search.html
+++ b/globus_portal_framework/templates/search.html
@@ -65,7 +65,7 @@
           results by displaying private results if you have permissions associated
           with your account.
         </div>
-        {% elif debug %}
+        {% elif globus_portal_framework.search_debugging_enabled %}
         <div class="alert alert-dark" role="alert">
           See Debugging for fields <a href="{% url 'search-debug' request.session.search.index %}">here</a>.
         </div>

--- a/globus_portal_framework/urls.py
+++ b/globus_portal_framework/urls.py
@@ -17,13 +17,13 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from globus_portal_framework.views import (
-    search, index_selection, search_debug, search_debug_detail,
-    detail, detail_transfer, detail_preview, logout
+    search, index_selection, detail, detail_transfer, detail_preview, logout
 )
 from globus_portal_framework.api import restricted_endpoint_proxy_stream
 
 # search detail for viewing info about a single search result
-detail_urlpatterns = [
+search_urlpatterns = [
+    path('<index>/', search, name='search'),
     path('<index>/detail-preview/<subject>/',
          detail_preview, name='detail-preview'),
     path('<index>/detail-preview/<subject>/<endpoint>/<path:url_path>/',
@@ -31,8 +31,6 @@ detail_urlpatterns = [
     path('<index>/detail-transfer/<subject>', detail_transfer,
          name='detail-transfer'),
     path('<index>/detail/<subject>/', detail, name='detail'),
-    path('<index>/search-debug-detail/<subject>/', search_debug_detail,
-         name='search-debug-detail'),
 ]
 
 urlpatterns = [
@@ -42,9 +40,7 @@ urlpatterns = [
     # Globus search portal. Provides default url '/'.
     path('logout/', logout, name='logout'),
     path('', index_selection, name='index-selection'),
-    path('<index>/', search, name='search'),
-    path('<index>/search-debug/', search_debug, name='search-debug'),
-    path('', include(detail_urlpatterns)),
+    path('', include(search_urlpatterns)),
 ]
 
 
@@ -53,4 +49,5 @@ if getattr(settings, 'GLOBUS_PORTAL_FRAMEWORK_DEVELOPMENT_APP', False):
     urlpatterns.extend([
         path('admin', admin.site.urls),
         path('', include('social_django.urls', namespace='social')),
+        path('', include('globus_portal_framework.urls_debugging'))
     ])

--- a/globus_portal_framework/urls_debugging.py
+++ b/globus_portal_framework/urls_debugging.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from globus_portal_framework.views import search_debug, search_debug_detail
+
+
+urlpatterns = [
+    path('<index>/search-debug/', search_debug, name='search-debug'),
+    path('<index>/search-debug-detail/<subject>/', search_debug_detail,
+         name='search-debug-detail'),
+]


### PR DESCRIPTION
Required as a part of #50, due to search debugging possibly revealing confidential search records. 