### PR TITLE
Fixed expired token middleware redirect

### DIFF
--- a/globus_portal_framework/tests/test_middleware.py
+++ b/globus_portal_framework/tests/test_middleware.py
@@ -1,10 +1,11 @@
 from datetime import timedelta
 from unittest import mock
+from urllib.parse import urlsplit, parse_qs, unquote_plus
 
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.http import HttpResponse
-from django.urls import path, reverse
+from django.urls import path, reverse, include
 from django.utils import timezone
 
 from globus_portal_framework import load_transfer_client, ExpiredGlobusToken
@@ -24,8 +25,8 @@ def mock_login_view(request):
 
 
 urlpatterns = [
-    path('', my_transfer_view, name='my_transfer_view'),
-    path('/login', mock_login_view, name='login')
+    path('my-transfer-view/', my_transfer_view, name='my_transfer_view'),
+    path('', include('social_django.urls', namespace='social')),
 ]
 
 T_MIDDLEWARE = 'globus_portal_framework.middleware.ExpiredTokenMiddleware'
@@ -53,6 +54,22 @@ class TestExpiredTokensMiddleware(TestCase):
             r = self.c.get(reverse('my_transfer_view'))
             self.assertEqual(r.status_code, 302)
         assert log.info.called
+
+    @mock.patch('globus_portal_framework.middleware.log')
+    @override_settings(ROOT_URLCONF=__name__, SESSION_COOKIE_AGE=9999999999)
+    def test_expired_token_redirect_handles_params(self, log):
+        # Tokens last 48 hours (Mocks are set to this). 72 is good leeway.
+        self.user.last_login = timezone.now() - timedelta(days=3)
+        self.user.save()
+        with self.modify_settings(MIDDLEWARE={'append': T_MIDDLEWARE}):
+            params = {'transfer': 'globus://myendpoint/file.txt'}
+            rurl = '{}?{}'.format(reverse('my_transfer_view'), params)
+            r = self.c.get(rurl)
+            self.assertEqual(r.status_code, 302)
+
+            next_url = parse_qs(urlsplit(r.url).query)['next'][0]
+            next_unquoted = unquote_plus(next_url)
+            self.assertEqual(next_unquoted, rurl)
 
     @override_settings(ROOT_URLCONF=__name__, SESSION_COOKIE_AGE=9999999999)
     def test_no_middleware_raises_exception(self):


### PR DESCRIPTION
Middleware would redirect to url named 'login', which I believe was
the old python social auth url. URL now redirects to 'social:begin'

Also fixed params handling, which may not have been fully captured
previously.