### PR TITLE
Fixed logout not respecting query parameters

### DIFF
--- a/globus_portal_framework/views.py
+++ b/globus_portal_framework/views.py
@@ -215,7 +215,13 @@ def detail_preview(request, index, subject, endpoint=None, url_path=None):
 
 
 def logout(request, next='/'):
+    """
+    Revoke the users tokens and pop their Django session. Users will be
+    redirected to the query parameter 'next' if it is present. If the 'next'
+    query parameter 'next' is not present, the parameter next will be used
+    instead.
+    """
     if request.user.is_authenticated:
         revoke_globus_tokens(request.user)
         django_logout(request)
-    return redirect(next)
+    return redirect(request.GET.get('next', next))


### PR DESCRIPTION
Changes for #90. This allows for putting links in templates that automatically redirect to a preferred location. Here is an example of redirecting users to the globusid page on logout:

    <a href="{% url 'logout' %}?next={{'https://www.globusid.org/logout'|urlencode:''}}">Logout</a>

Note on IdP redirects: Globus Portal Framework does not track providers and can't automatically determine which provider logout to use for any given user. A more likely scenario would be restricting users to a single IdP, such as globusid above, so that logout would always redirect users to the correct location. 