### PR TITLE
Fixed possible bug if user was redirected to custom view after logout

### DIFF
--- a/globus_portal_framework/templates/search-debug-detail.html
+++ b/globus_portal_framework/templates/search-debug-detail.html
@@ -35,7 +35,7 @@
 
     <div class="card">
         <div class="card-header">
-          <h3>Search Index: {{request.session.search.index}}</h3>
+          <h3>Search Index: {{globus_portal_framework.index}}</h3>
         </div>
 
         <div class="card-body">

--- a/globus_portal_framework/templates/search-debug.html
+++ b/globus_portal_framework/templates/search-debug.html
@@ -36,7 +36,7 @@
 
     <div class="card">
         <div class="card-header">
-          <h3>Debugging Data For {{request.session.search.index}}</h3>
+          <h3>Debugging Data For {{globus_portal_framework.index}}</h3>
         </div>
 
         <div class="card-body">

--- a/globus_portal_framework/templates/search.html
+++ b/globus_portal_framework/templates/search.html
@@ -35,7 +35,7 @@
     {% include it_mess %}
   </div>
 
-  <form id="search-form" class="my-4" name="search_form" action="{% url 'search' request.session.search.index %}">
+  <form id="search-form" class="my-4" name="search_form" action="{% url 'search' globus_portal_framework.index %}">
     <input type="text" id="search-input" autocomplete="off"
            data-provide="typeahead" name="q"
            value="{{request.session.search.query}}" placeholder="Start your search here">
@@ -48,7 +48,7 @@
     <div id="sidebar" class="col-xs-12 col-sm-4 col-md-4">
       <div id="filters">
         <div id="facet-container">
-          <form id="facet-form" action="{% url 'search' request.session.search.index %}">
+          <form id="facet-form" action="{% url 'search' globus_portal_framework.index %}">
             {% index_template "components/search-facets.html" as it_facets %}
             {% include it_facets %}
           </form>
@@ -67,7 +67,7 @@
         </div>
         {% elif globus_portal_framework.search_debugging_enabled %}
         <div class="alert alert-dark" role="alert">
-          See Debugging for fields <a href="{% url 'search-debug' request.session.search.index %}">here</a>.
+          See Debugging for fields <a href="{% url 'search-debug' globus_portal_framework.index %}">here</a>.
         </div>
         {% endif %}
 


### PR DESCRIPTION
Fix for #92


Some URLs depended on the user session, and would cause an error
if the user session was popped. The new URLs depend on the global
context constructed by Globus Portal Framework, which are
guaranteed to be set when a user loads a view as long as that context
is set within settings.py.