### PR TITLE
Added feature/bugfix to allow registering custom indices

### DIFF
--- a/globus_portal_framework/tests/test_urls.py
+++ b/globus_portal_framework/tests/test_urls.py
@@ -1,0 +1,41 @@
+import sys
+from urllib.parse import quote_plus
+
+from django.test import TestCase, Client
+from django.test.utils import override_settings
+
+from globus_portal_framework.tests.mocks import rebuild_index_urlpatterns
+
+from globus_portal_framework.urls import (search_urlpatterns,
+                                          register_custom_index,
+                                          urlpatterns as dgpf_urlpatterns)
+from globus_portal_framework.exc import IndexNotFound
+
+SEARCH_INDEXES = {'myindex': {
+    # Randomly generated and not real
+    'uuid': '1e0be00f-8156-499e-980d-f7fb26157c02'
+}}
+
+thismodule = sys.modules[__name__]
+
+
+@override_settings(SEARCH_INDEXES=SEARCH_INDEXES, ROOT_URLCONF=__name__)
+class SearchViewsTest(TestCase):
+
+    def setUp(self):
+        self.c = Client()
+        # Mock endpoint for transfer and preview (Globus HTTPS)
+        self.foo_ep = 'eae9d78d-b353-4fa7-9dbe-c60d681bc783'
+        # A valid subject url given our views
+        self.subject_url = quote_plus('globus://{}/{}'.format(self.foo_ep,
+                                                              'foo'))
+        # Setup tests so our urlpatterns contain the indexes in SEARCH_INDEXES
+        # defined above.
+        urlpatterns = rebuild_index_urlpatterns(
+            search_urlpatterns + dgpf_urlpatterns,
+            list(SEARCH_INDEXES.keys()))
+        setattr(thismodule, 'urlpatterns', urlpatterns)
+
+    def test_register_non_existant_index_raises_error(self):
+        with self.assertRaises(IndexNotFound):
+            register_custom_index('foo', ['bar'])

--- a/globus_portal_framework/tests/test_views.py
+++ b/globus_portal_framework/tests/test_views.py
@@ -1,3 +1,4 @@
+import sys
 from copy import deepcopy
 from unittest import mock
 from urllib.parse import quote_plus
@@ -18,13 +19,13 @@ from globus_portal_framework import (
 from globus_portal_framework.urls import (search_urlpatterns,
                                           urlpatterns as dgpf_urlpatterns)
 
+thismodule = sys.modules[__name__]
+
 
 SEARCH_INDEXES = {'myindex': {
     # Randomly generated and not real
     'uuid': '1e0be00f-8156-499e-980d-f7fb26157c02'
 }}
-
-urlpatterns = rebuild_index_urlpatterns(search_urlpatterns + dgpf_urlpatterns)
 
 
 MOCK_RFM = [
@@ -56,6 +57,12 @@ class SearchViewsTest(TestCase):
         self.subject_url = quote_plus('globus://{}/{}'.format(self.foo_ep,
                                                               'foo'))
         self.index = 'myindex'
+        # Setup tests so our urlpatterns contain the indexes in SEARCH_INDEXES
+        # defined above.
+        urlpatterns = rebuild_index_urlpatterns(
+            search_urlpatterns + dgpf_urlpatterns,
+            list(SEARCH_INDEXES.keys()))
+        setattr(thismodule, 'urlpatterns', urlpatterns)
 
     @mock.patch('globus_portal_framework.views.post_search')
     def test_index(self, post_search):

--- a/globus_portal_framework/tests/test_views_custom.py
+++ b/globus_portal_framework/tests/test_views_custom.py
@@ -1,0 +1,68 @@
+import sys
+from unittest import mock
+
+from django.test import TestCase, Client
+from django.test.utils import override_settings
+from django.urls import reverse, path
+from django.http import HttpResponse
+
+from globus_portal_framework.tests import test_gsearch, MOCK_RESULT
+from globus_portal_framework.tests.mocks import rebuild_index_urlpatterns
+
+from globus_portal_framework.urls import (search_urlpatterns,
+                                          register_custom_index,
+                                          urlpatterns as dgpf_urlpatterns)
+thismodule = sys.modules[__name__]
+
+
+class MockSearchGetSubject:
+    def __init__(self):
+        self.data = test_gsearch.get_mock_data(MOCK_RESULT)
+
+
+SEARCH_INDEXES = {
+    'myindex': {
+        # Randomly generated and not real
+        'uuid': '1e0be00f-8156-499e-980d-f7fb26157c02'
+    },
+    'my_custom_index': {
+        # Randomly generated and not real
+        'uuid': '1e0be00f-8156-499e-980d-f7fb26157c02'
+    }
+}
+
+
+@override_settings(SEARCH_INDEXES=SEARCH_INDEXES, ROOT_URLCONF=__name__)
+class CustomViewsTest(TestCase):
+
+    def setUp(self):
+        self.c = Client()
+        # Mock endpoint for transfer and preview (Globus HTTPS)
+
+        register_custom_index('my_custom_index', ['my_custom_index'])
+
+        urlpatterns = rebuild_index_urlpatterns(
+            search_urlpatterns + dgpf_urlpatterns,
+            list(SEARCH_INDEXES.keys()))
+        self.custom_search = mock.Mock(
+            return_value=HttpResponse('custom_search_view'))
+        custom_path = path('<my_custom_index:index>/', self.custom_search,
+                           name='search')
+        urlpatterns.insert(0, custom_path)
+        setattr(thismodule, 'urlpatterns', urlpatterns)
+
+    @mock.patch('globus_portal_framework.views.post_search')
+    def test_custom_search_view(self, post_search):
+        post_search.return_value = {}
+        r = self.c.get(reverse('search', args=['my_custom_index']))
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(self.custom_search.called)
+        self.assertEqual(r.content, b'custom_search_view')
+
+    @mock.patch('globus_portal_framework.views.post_search')
+    def test_regular_search_view_not_affected(self, post_search):
+        post_search.return_value = {}
+        r = self.c.get(reverse('search', args=['myindex']))
+        self.assertEqual(r.status_code, 200)
+        self.assertFalse(self.custom_search.called)
+        self.assertNotEqual(r.content, b'custom_search_view')

--- a/globus_portal_framework/urls.py
+++ b/globus_portal_framework/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+import logging
 from django.contrib import admin
 from django.urls import path, include, register_converter
 from django.conf import settings
@@ -20,9 +21,19 @@ from globus_portal_framework.views import (
     search, index_selection, detail, detail_transfer, detail_preview, logout
 )
 from globus_portal_framework.api import restricted_endpoint_proxy_stream
+from globus_portal_framework.exc import IndexNotFound
+
+
+log = logging.getLogger(__name__)
 
 
 class IndexConverter:
+
+    def __init__(self):
+        log.warning('Deprecation Warning: The IndexConverter class will be '
+                    'removed in the next version. Please use '
+                    'globus_portal_framework.urls.register_custom_index '
+                    'instead.')
 
     @property
     def regex(self):
@@ -37,7 +48,45 @@ class IndexConverter:
         return value
 
 
-register_converter(IndexConverter, 'index')
+def register_custom_index(name, match_list):
+    """Register a new index converter for a list of names. This is handy if
+    you have two or more indices that use the same views. You can then specify
+    URLs which will ONLY match the list you provide, and won't steal URLs from
+    other indices.
+
+    Examples:
+      register_index_converter('tabbed-project', ['myproject1', 'myproject2'])
+    In the example above, myproject1 and myproject2 can be routed for custom
+    views without stealing views from myproject3. URLs could then look like:
+
+    urlpatterns = [
+        path('<tabbed-project:index>/search/', search, name='tp-search'),
+    ]
+
+    This example defines a custom search for myproject1 and myproject2 but NOT
+    myproject3, myproject4, etc. Anything that does not match the list will
+    simply fall through.
+    """
+    for index in match_list:
+        if index not in settings.SEARCH_INDEXES.keys():
+            raise IndexNotFound(index)
+
+    class CustomIndexConverter:
+
+        @property
+        def regex(self):
+            return '({})'.format('|'.join(match_list))
+
+        def to_python(self, value):
+            return value
+
+        def to_url(self, value):
+            return value
+
+    register_converter(CustomIndexConverter, name)
+
+
+register_custom_index('index', list(settings.SEARCH_INDEXES.keys()))
 
 # search detail for viewing info about a single search result
 search_urlpatterns = [


### PR DESCRIPTION
Resolves #98 

This is a bugfix in the sense that previously it was possible but not easy to add a custom view to one or more indices without it consuming ALL strings that matched the given url. For example, the docs specify adding the following:

    path('<index>/', mysearch, name='search'),

This will match all indices, but also other random stuff which isn't an error. For example, 'favicon.ico' is a file the browser may try to fetch automatically, which the above `path` will treat as a url, raising the `IndexNotFound` Exception. 

The new functionality allows the following:

```
register_custom_index('custom_search_1', ['foo_index', 'bar_index'])
register_custom_index('custom_search_2', ['moo_index'])

urlpatterns = [
    path('<custom_search_1:index>/', custom_search, name='search'),
    path('<custom_search_2:index>/', other_custom_search, name='search'),
    path('', include('globus_portal_framework.urls')),
]
```
With the above: 

* 'foo_index' and 'bar_index' will be routed to the 'custom_search' view
* 'moo_index' will be routed to 'other_custom_search' view
* 'goo_index' will use the normal Globus Portal Framework search view
* 'favicon.ico' will return a 404