### PR TITLE
Added many extended search args which can be configured per-index

### DIFF
--- a/globus_portal_framework/constants.py
+++ b/globus_portal_framework/constants.py
@@ -50,6 +50,11 @@ DATETIME_PARTIAL_FORMATS = {
     'time': '%Y-%m-%d %H:%M:%S'
 }
 
+VALID_SEARCH_KEYS = [
+    'q', 'limit', 'offset', 'facets', 'filters', 'boosts', 'sort',
+    'query_template', 'advanced', 'bypass_visible_to', 'result_format_version',
+]
+
 VALID_SEARCH_FACET_KEYS = [
     'name', 'type', 'field_name', 'size', 'histogram_range', 'date_interval'
 ]


### PR DESCRIPTION
Extended the core `post_search` function to allow pass-through of extended Globus Search args. Anything defined in the [query docs](https://docs.globus.org/api/search/search/) can be used, including old features not previously supported like gsort and gboost, and newer features like `bypass_visible_to`. These can be configured by adding these settings to the index definitions. Or, if someone is developing their own views using `post_search`, these can be passed in via the new `search_kwargs` dict arg. 

I also updated the docs for the post_search function, which previously was outdated and not very helpful. 