### PR TITLE
Added default search results format

### DIFF
--- a/globus_portal_framework/checks.py
+++ b/globus_portal_framework/checks.py
@@ -72,6 +72,17 @@ def check_search_indexes(app_configs, **kwargs):
                 id='globus_portal_framework.settings.E001'
                 )
             )
+        if idata.get('result_format_version') == '2019-08-27':
+            errors.append(Warning(
+                'Globus Portal Framework does not support '
+                'result_format_version=="2019-08-27"',
+                obj=settings,
+                hint=('Suggested you unset '
+                      'settings.SEARCH_INDEXES.{}.result_format_version'
+                      ''.format(index_name)),
+                id='globus_portal_framework.settings.E002'
+                )
+            )
         fm = idata.get('filter_match', None)
         if fm is not None and fm not in FILTER_TYPES.keys():
             errors.append(

--- a/globus_portal_framework/constants.py
+++ b/globus_portal_framework/constants.py
@@ -58,3 +58,5 @@ VALID_SEARCH_KEYS = [
 VALID_SEARCH_FACET_KEYS = [
     'name', 'type', 'field_name', 'size', 'histogram_range', 'date_interval'
 ]
+# https://docs.globus.org/api/search/search/#request_documents
+DEFAULT_RESULT_FORMAT_VERSION = '2017-09-01'

--- a/globus_portal_framework/gsearch.py
+++ b/globus_portal_framework/gsearch.py
@@ -22,6 +22,8 @@ from globus_portal_framework.constants import (
     FILTER_SECOND,
 
     VALID_SEARCH_FACET_KEYS, VALID_SEARCH_KEYS,
+
+    DEFAULT_RESULT_FORMAT_VERSION,
 )
 FILTER_RANGE_SEPARATOR = getattr(settings, 'FILTER_RANGE_SEPARATOR',
                                  FILTER_DEFAULT_RANGE_SEPARATOR)
@@ -87,6 +89,8 @@ def post_search(index, query, filters, user=None, page=1, search_kwargs=None):
         'limit': get_setting('SEARCH_RESULTS_PER_PAGE')
     })
     search_data.update(search_kwargs or {})
+    search_data['result_format_version'] = search_data.get(
+        'result_format_version', DEFAULT_RESULT_FORMAT_VERSION)
     try:
         result = client.post_search(index_data['uuid'], search_data)
         return {


### PR DESCRIPTION
Part of #91 -- Set `result_format_version` to `2017-09-01`

This is ahead of the newer search format switching over next month,
in which case the newer version will become default. Globus Portal
Framework does not currently support the newest version, so this will
allow the current version to continue working normally.