### PR TITLE
Added broad catch for facet modifiers to catch most exceptions

### DIFF
--- a/globus_portal_framework/modifiers/facets.py
+++ b/globus_portal_framework/modifiers/facets.py
@@ -22,7 +22,7 @@ def sort_terms(facets):
     """Sort terms lexicographically instead of by the number of results
     returned. This will only sort 'terms' type facets."""
     for facet in facets:
-        if facet['type'] == 'terms':
+        if facet['type'] == 'terms' and facet.get('buckets'):
             facet['buckets'].sort(key=lambda x: x['value'])
     return facets
 
@@ -32,7 +32,7 @@ def sort_terms_numerically(facets):
     applies to 'terms' type facets, and facets that contain only numbers
     in their buckets."""
     for facet in facets:
-        if facet['type'] == 'terms':
+        if facet['type'] == 'terms' and facet.get('buckets'):
             try:
                 facet['buckets'].sort(key=lambda x: float(x['value']))
             except ValueError:


### PR DESCRIPTION
Like fields, facet-modifiers shouldn't prevent the search page from
loading. If a facet-modifier raises an exception (except an import
exception), the exception will be logged but not allowed to disrupt
the search page