### PR TITLE
Fixed python 3.5 incompatibilites

### DIFF
--- a/globus_portal_framework/gsearch.py
+++ b/globus_portal_framework/gsearch.py
@@ -853,7 +853,7 @@ def get_facets(search_result, portal_defined_facets, filters,
     for fmodder in facet_modifiers:
         try:
             facets = import_string(fmodder)(facets)
-        except ModuleNotFoundError:
+        except ImportError:
             # Don't catch these. Developer error.
             raise
         except Exception as e:

--- a/globus_portal_framework/tests/test_gsearch.py
+++ b/globus_portal_framework/tests/test_gsearch.py
@@ -426,7 +426,7 @@ class TestGSearch(TestCase):
         mock_mods = ['globus_portal_framework.tests.test_gsearch.exc_mod']
         get_facets(search_response, MOCK_PORTAL_DEFINED_FACETS, [],
                    filter_match=None, facet_modifiers=mock_mods)
-        self.asserTrue(exc_mod.called)
+        self.assertTrue(exc_mod.called)
 
     def test_get_invalid_search_range_raises_error(self):
         with self.assertRaises(GlobusPortalException):


### PR DESCRIPTION
* ModuleNotFoundError is a subset of ImportError introduced in
python 3.6
* typo in assert