### PR TITLE
Cap social-auth-app-django at 3.x.x (4.x.x has problems).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=2.1.4
 globus_sdk>=1.5.0
-social-auth-app-django>=3.1.0
+social-auth-app-django>=3.1.0,<4.0.0
 python-jose[cryptography]>=3.0.1


### PR DESCRIPTION
Thanks Lukasz for finding this! 

4.0.0 results in an exception when logging in. I haven't taken the time to pin down the cause, but it doesn't appear to be anything significant from the [changelog](https://github.com/python-social-auth/social-app-django/blob/master/CHANGELOG.md). 