### PR TITLE
Pinned social-auth-core to under 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 Below are major changes for each version Release. For detailed information,
 see the list of commits from the last version or use `git log`.
 
+## 0.3.21 - 2021-03-12
+
+- Pinned social-auth-core to 3.x.x, which wasn't always set by pinning social-auth-app-django
+
 ## 0.3.20 - 2021-03-09
 
 - Pinned social-auth-app-django to 3.x.x due to bug in 4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 django>=2.1.4
 globus_sdk>=1.5.0
 social-auth-app-django>=3.1.0,<4.0.0
+social-auth-core<4.0.0
 python-jose[cryptography]>=3.0.1


### PR DESCRIPTION
Pin social-auth-core requirement to 3.x.x to avoid exception when logging in.

See https://github.com/globusonline/django-globus-portal-framework/pull/134