### PR TITLE
Fix mistaken requirements in last merge

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django<4.0.0
-globus_sdk<4.0.0,>=3.0.0
+globus_sdk<4.0.0
 social-auth-app-django
 social-auth-core


### PR DESCRIPTION
* Requirements improperly pinned => v3, v2 SDK compatibility will
remain for now