### PR TITLE
chore: Remove default app config

### DIFF
--- a/globus_portal_framework/__init__.py
+++ b/globus_portal_framework/__init__.py
@@ -47,5 +47,3 @@ __all__ = [
     'get_helper_page_url', 'is_file',
 
 ]
-
-default_app_config = 'globus_portal_framework.apps.GlobusPortalFrameworkConfig'


### PR DESCRIPTION
No longer required in Django 3+