### PR TITLE
Add PyPi Publish Workflow on Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on: push
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+          .
+      - name: Publish distribution 📦 to Test PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,4 +18,5 @@ recursive-include globus_portal_framework *.woff
 recursive-include globus_portal_framework *.woff2
 
 exclude globus_portal_framework/local_settings.py
+prune tests/
 global-exclude local_settings.py

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os.path
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 
 # single source of truth for package version
@@ -25,7 +25,7 @@ setup(name='django-globus-portal-framework',
       author='Globus Team',
       author_email='support@globus.org',
       url='https://github.com/globus/django-globus-portal-framework',
-      packages=find_packages(exclude=['local*']),
+      packages=find_namespace_packages(include=['globus_portal_framework*']),
       install_requires=install_requires,
       include_package_data=True,
       keywords=['globus', 'django'],


### PR DESCRIPTION
Build and publish packages using github actions. Minor fixes added for setuptools. Tests are now pruned from releases.