### PR TITLE
fix: Upgrade internals from legacy search result format to 2019-08-27

### DIFF
--- a/globus_portal_framework/constants.py
+++ b/globus_portal_framework/constants.py
@@ -62,7 +62,7 @@ VALID_SEARCH_FACET_KEYS = [
     'missing'
 ]
 # https://docs.globus.org/api/search/search/#request_documents
-DEFAULT_RESULT_FORMAT_VERSION = '2017-09-01'
+DEFAULT_RESULT_FORMAT_VERSION = '2019-08-27'
 
 BASE_TEMPLATES = 'globus-portal-framework/v2/'
 

--- a/tests/data/get_subject.json
+++ b/tests/data/get_subject.json
@@ -1,16 +1,18 @@
 {
     "@datatype": "GMetaResult",
-    "@version": "2017-09-01",
-    "content": [
+    "@version": "2019-08-27",
+    "entries": [
         {
-            "globus_group": "b1208858-fc85-11e7-aca1-0ed2d3184bea",
-            "remote_file_manifest": [{
-                "filename": "iozone_log_ccs_dtn36_atlas1_50G_default.txt",
-                "length": 26716,
-                "md5": "48261c5f5f9d677a9ae6e4bed22a9f39",
-                "sha256": "b2e88ea7587409e5ba92a323d7a1c44736fd587bbe00128a95df9cbcd4bcc957",
-                "url": "globus://cf619dbb-623b-41fa-8988-1f3d26ebd887/ORNL/iozone/iozone_log_ccs_dtn36_atlas1_50G_default.txt"
-            }]
+            "content": {
+                "globus_group": "b1208858-fc85-11e7-aca1-0ed2d3184bea",
+                "remote_file_manifest": [{
+                    "filename": "iozone_log_ccs_dtn36_atlas1_50G_default.txt",
+                    "length": 26716,
+                    "md5": "48261c5f5f9d677a9ae6e4bed22a9f39",
+                    "sha256": "b2e88ea7587409e5ba92a323d7a1c44736fd587bbe00128a95df9cbcd4bcc957",
+                    "url": "globus://cf619dbb-623b-41fa-8988-1f3d26ebd887/ORNL/iozone/iozone_log_ccs_dtn36_atlas1_50G_default.txt"
+                }]
+            }
         }
     ],
     "subject": "globus://cf619dbb-623b-41fa-8988-1f3d26ebd887/ORNL/iozone/iozone_log_ccs_dtn36_atlas1_50G_default.txt"

--- a/tests/data/search_legacy.json
+++ b/tests/data/search_legacy.json
@@ -1,13 +1,13 @@
 {
     "@datatype": "GSearchResult",
-    "@version": "2019-08-27",
+    "@version": "2017-09-01",
     "count": 1,
     "gmeta": [
         {
             "@datatype": "GMetaResult",
-            "@version": "2019-08-27",
-            "entries": [{
-                "content": {
+            "@version": "2017-09-01",
+            "content": [
+                {
                     "globus_group": "ce3ef838-44c1-473e-aecb-c3ecfe6698db",
                     "remote_file_manifest": [
                         {
@@ -29,10 +29,8 @@
                             "md5":"febe6995bad457991331348f7b9c85fa"
                         }
                     ]
-                },
-                "entry_id": null,
-                "matched_principal_sets": []
-            }],
+                }
+            ],
             "subject": "globus://ddb59aef-6d04-11e5-ba46-22000b92c6ec:/share/godata/"
         }
     ],

--- a/tests/test_gsearch.py
+++ b/tests/test_gsearch.py
@@ -170,42 +170,48 @@ def test_process_search_data_with_no_records():
 
 
 def test_process_search_data_zero_length_content(mock_data):
-    sub = mock_data['search']['gmeta'][0]
-    sub['content'] = []
-    mappers, results = [], [sub]
+    gmeta = mock_data['search']['gmeta'][0]
+    gmeta['entries'] = []
+    mappers, results = [], [gmeta]
     data = process_search_data(mappers, results)
     assert data == []
 
 
-def test_process_search_data_with_one_entry(mock_data):
-    sub = mock_data['search']['gmeta'][0]
+def test_process_search_data_skips_legacy(mock_data):
+    sub = mock_data['search_legacy']['gmeta'][0]
     mappers, results = [], [sub]
-    data = process_search_data(mappers, results)[0]
-    assert quote_plus(sub['subject']) == data['subject']
-    assert sub['content'] == data['all']
+    assert process_search_data(mappers, results) == []
+
+
+def test_process_search_data_with_one_entry(mock_data):
+    # First search record
+    gmeta = mock_data['search']['gmeta'][0]
+    processsed_content = process_search_data([], [gmeta])
+    assert processsed_content
+    assert quote_plus(gmeta['subject']) == processsed_content[0]['subject']
+    assert gmeta['entries'][0]['content'] == processsed_content[0]['all'][0]
 
 
 def test_process_search_data_string_field(mock_data):
-    sub = mock_data['search']['gmeta'][0]
-    sub['content'][0]['foo'] = 'bar'
-    mappers, results = ['foo'], [sub]
-    data = process_search_data(mappers, results)[0]
+    gmeta = mock_data['search']['gmeta'][0]
+    gmeta['entries'][0]['content']['foo'] = 'bar'
+    data = process_search_data(['foo'], [gmeta])[0]
     assert data['foo'] == 'bar'
 
 
 def test_process_search_data_func_field(mock_data):
-    sub = mock_data['search']['gmeta'][0]
-    sub['content'][0]['foo'] = 'bar'
+    gmeta = mock_data['search']['gmeta'][0]
+    gmeta['entries'][0]['content']['foo'] = 'bar'
     mappers = [('foo', lambda x: x[0].get('foo').replace('b', 'c'))]
-    results = [sub]
+    results = [gmeta]
     data = process_search_data(mappers, results)[0]
     assert data['foo'] == 'car'
 
 
 def test_process_search_data_string_field_missing(mock_data):
-    sub = mock_data['search']['gmeta'][0]
-    sub['content'][0]['foo'] = 'bar'
-    mappers, results = ['foo'], [sub]
+    gmeta = mock_data['search']['gmeta'][0]
+    gmeta['entries'][0]['content']['foo'] = 'bar'
+    mappers, results = ['foo'], [gmeta]
     data = process_search_data(mappers, results)[0]
     assert data['foo'] == 'bar'
 


### PR DESCRIPTION
The changes here are purposefully simplistic to upgrade a very overdue API result format. The fields system for processing entries is still not ideal for a few different reasons, and should be made better for both the ease of configuring fields in DGPF and handling different kinds of entries. Those will be addressed later. For now, these changes simply upgrade to the newer API version while preserving backwards compatibility.