### PR TITLE
refactor: Remove old globus-sdk v2 era code

### DIFF
--- a/globus_portal_framework/checks.py
+++ b/globus_portal_framework/checks.py
@@ -3,8 +3,9 @@ from django.core.checks import Error, Warning, register
 from django.conf import settings
 import globus_sdk
 
-from globus_portal_framework.constants import FILTER_TYPES
-from globus_portal_framework.gclients import get_globus_environment
+from globus_portal_framework.constants import (
+    FILTER_TYPES, DEFAULT_RESULT_FORMAT_VERSION
+)
 
 log = logging.getLogger(__name__)
 log.debug('Debugging is active.')
@@ -92,17 +93,16 @@ def check_search_indexes(app_configs, **kwargs):
                 Warning('SEARCH_INDEXES.{}.filter_match is invalid.'
                         ''.format(index_name),
                         obj=settings,
-                        hint='Must be one of {}'.format(
-                            tuple(FILTER_TYPES.keys()))
+                        hint=f'Must be one of {tuple(FILTER_TYPES.keys())}'
                         ))
     return errors
 
 
 @register()
 def check_globus_env(app_configs, **kwargs):
-    env = get_globus_environment()
-    # 'default' is used in Globus SDK v2, 'production' in v3
-    if env not in ['default', 'production']:
-        return [Warning('Environment set to "{}", unset with '
-                        '"unset GLOBUS_SDK_ENVIRONMENT"'.format(env))]
+    env = os.getenv('GLOBUS_SDK_ENVIRONMENT')
+    if env and env != 'production':
+        return [Info(f'GLOBUS_SDK_ENVIRONMENT set to "{env}".',
+                     hint='Non-production services may contain experimental '
+                          'features.')]
     return []

--- a/globus_portal_framework/views/base.py
+++ b/globus_portal_framework/views/base.py
@@ -265,8 +265,15 @@ def allowed_groups(request):
     context = {'allowed_groups': copy.deepcopy(portal_groups)}
     if request.user.is_authenticated:
         try:
-            user_groups = {g['id']: g
-                           for g in gclients.get_user_groups(request.user)}
+            groups_client = gclients.load_globus_client(
+                    request.user,
+                    globus_sdk.GroupsClient,
+                    'groups.api.globus.org',
+                    require_authorized=True
+            )
+            user_groups = {
+                g['id']: g for g in groups_client.get_user_groups(request.user)
+            }
             for group in context['allowed_groups']:
                 if user_groups.get(group['uuid']):
                     group['is_member'] = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,12 @@ def search_client(monkeypatch):
 
 
 @pytest.fixture
+def groups_client(monkeypatch):
+    monkeypatch.setattr(globus_sdk, 'GroupsClient', Mock())
+    return globus_sdk.GroupsClient
+
+
+@pytest.fixture
 def search_client_inst(search_client):
     """Return a search client instance"""
     return search_client.return_value

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -183,25 +183,24 @@ def test_without_allowed_groups(settings, user_details):
 
 
 def test_with_one_group(settings, mock_group_tokens, groups,
-                        user_details, get_json):
+                        user_details, groups_client):
     settings.SOCIAL_AUTH_GLOBUS_ALLOWED_GROUPS = [
        {'name': 'Portal Users Group',
         'uuid': 'test-group-1-uuid'}
     ]
-    # mock GlobusOpenIdConnect routine to fetch groups
-    get_json.return_value = groups
+    groups_client.return_value.get_user_groups.return_value = groups
     goidc = GlobusOpenIdConnect()
     response = {'other_tokens': mock_group_tokens}
     assert goidc.auth_allowed(response, user_details) is True
 
 
-def test_with_no_groups(settings, mock_group_tokens, user_details, get_json):
+def test_with_no_groups(settings, mock_group_tokens, user_details, groups_client):
     settings.SOCIAL_AUTH_GLOBUS_ALLOWED_GROUPS = [
        {'name': 'Portal Users Group',
         'uuid': 'test-group-1-uuid'}
     ]
     # Globus returns no groups
-    get_json.return_value = []
+    groups_client.return_value.get_user_groups.return_value = []
     goidc = GlobusOpenIdConnect()
     response = {'other_tokens': mock_group_tokens}
     with pytest.raises(social_core.exceptions.AuthForbidden):
@@ -209,11 +208,12 @@ def test_with_no_groups(settings, mock_group_tokens, user_details, get_json):
 
 
 def test_with_wrong_identity(settings, mock_group_tokens, user_details, groups,
-                             get_json):
+                             groups_client):
     settings.SOCIAL_AUTH_GLOBUS_ALLOWED_GROUPS = [
        {'name': 'Portal Users Group',
         'uuid': 'test-group-1-uuid'}
     ]
+    groups_client.return_value.get_user_groups.return_value = groups
     get_json.return_value = groups
     response = {'other_tokens': mock_group_tokens}
     goidc = GlobusOpenIdConnect()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -160,10 +160,9 @@ def test_allowed_groups(client):
 
 
 @pytest.mark.django_db
-def test_allowed_groups_with_user(user, client, monkeypatch):
-    get = mock.Mock()
-    get.return_value.json.return_value = []
-    monkeypatch.setattr(requests, 'get', get)
+def test_allowed_groups_with_user(groups_client, user, client, mock_data, globus_response):
+    globus_response.data = mock_data['get_user_groups']
+    groups_client.return_value.get_user_groups.return_value = mock_data['get_user_groups']
     client.force_login(user)
     r = client.get(reverse('allowed-groups'))
     assert r.status_code == 200


### PR DESCRIPTION
A handful of code, mainly around groups, was not yet implemented in the Globus SDK and had to be implemented here manually. That has now been removed, simplifying calls into the Globus API.