### PR TITLE
feat: Add support for Django 5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django<5
+django<6
 globus_sdk>=3,<4
 social-auth-app-django>=3.0.0,<6.0.0
 python-jose[cryptography]>=3.0.1


### PR DESCRIPTION
Add support for the Django 5 Release https://docs.djangoproject.com/en/5.0/releases/5.0/

No action needs to be taken here for DGPF, no backwards incompatible changes were found, and all users are encouraged to upgrade when they are ready.