### PR TITLE
Add public feature to login with Groups

### DIFF
--- a/globus_portal_framework/middleware.py
+++ b/globus_portal_framework/middleware.py
@@ -56,6 +56,7 @@ class GlobusAuthExceptionMiddleware(MiddlewareMixin):
         kwargs = exception.args[0]
         allowed_user_member_groups = kwargs.get('allowed_user_member_groups')
         if not allowed_user_member_groups:
+            # Ideally, this would be configurable
             return HttpResponseRedirect(reverse('allowed-groups'))
 
         req_ids = [g['identity_id'] for g in allowed_user_member_groups]

--- a/globus_portal_framework/views/base.py
+++ b/globus_portal_framework/views/base.py
@@ -272,7 +272,7 @@ def allowed_groups(request):
                     require_authorized=True
             )
             user_groups = {
-                g['id']: g for g in groups_client.get_user_groups(request.user)
+                g['id']: g for g in groups_client.get_my_groups()
             }
             for group in context['allowed_groups']:
                 if user_groups.get(group['uuid']):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,9 +6,14 @@ from tests.mocks import mock_tokens
 from globus_portal_framework.auth import GlobusOpenIdConnect
 
 
+class MockResponseEnvelope:
+    def __init__(self, data=[]):
+        self.data = data
+
+
 @pytest.fixture
 def groups():
-    return [
+    return MockResponseEnvelope([
         {
             'name': 'Test Group 1',
             'enforce_session': False,
@@ -36,7 +41,7 @@ def groups():
                 }
             ]
         }
-    ]
+    ])
 
 
 @pytest.fixture
@@ -50,6 +55,7 @@ def user_details():
         'identity_id': 'mal-ident-1-uuid',
         'idp_id': 'ident-uuid',
         'identities': [],
+        'sub': 'mal-ident-1-uuid',
     }
 
 
@@ -65,50 +71,6 @@ def mock_group_tokens():
 def tokens():
     return mock_tokens(['urn:globus:auth:scope:groups.api.globus.org:'
                        'view_my_groups_and_memberships'])
-
-
-@pytest.fixture
-def get_json(monkeypatch):
-    monkeypatch.setattr(GlobusOpenIdConnect, 'get_json', Mock())
-    return GlobusOpenIdConnect.get_json
-
-
-@pytest.fixture
-def introspect_response(monkeypatch, settings):
-    resp = {
-        'active': True,
-        'aud': ['auth.globus.org', settings.SOCIAL_AUTH_GLOBUS_KEY],
-        'client_id': settings.SOCIAL_AUTH_GLOBUS_KEY,
-        'dependent_tokens_cache_id': '8fa8acb8bdafda7a4138c70607a32d4e'
-                                     '83179f319be6823ff0c8549908adbf85',
-        'email': 'mal@globus.org',
-        'exp': 1632671003,
-        'iat': 1632498203,
-        'identities_set': [
-            'mal-ident-1-uuid',
-        ],
-        'iss': 'https://auth.globus.org',
-        'name': 'Malcolm Reynolds',
-        'nbf': 1632498203,
-        'scope': 'profile openid email',
-        'session_info': {
-            'authentications': {
-                'mal-ident-1-uuid': {
-                    'acr': 'urn:oasis:names:tc:SAML:2.0:ac:classes:'
-                           'PasswordProtectedTransport',
-                    'amr': None,
-                    'auth_time': 1632498192,
-                    'idp': 'ident-uuid'},
-            },
-            'session_id': 'f89aded8-bacd-4a6f-819b-ecb1fd353779'
-        },
-        'sub': 'mal-sub-uuid',
-        'token_type': 'Bearer',
-        'username': 'mal@globusid.org'
-    }
-    monkeypatch.setattr(GlobusOpenIdConnect, 'introspect_token',
-                        Mock(return_value=resp))
-    return GlobusOpenIdConnect.introspect_token
 
 
 @pytest.fixture
@@ -139,43 +101,6 @@ def globus_identities(monkeypatch):
     return GlobusOpenIdConnect.get_globus_identities
 
 
-def test_get_user_details(introspect_response, globus_identities):
-    goidc = GlobusOpenIdConnect()
-    details = goidc.get_user_details({'access_token': 'mock_access_token',
-                                      'identities_set': []})
-    assert details == {
-        'email': 'mal@globus.org',
-        'first_name': 'Malcolm',
-        'fullname': 'Malcolm Reynolds',
-        'identities': {'identities': [{'email': 'mal@globus.org',
-                                       'id': 'mal-ident-1-uuid',
-                                       'identity_provider': 'ident-uuid',
-                                       'identity_type': 'login',
-                                       'name': 'Malcolm Reynolds',
-                                       'organization': None,
-                                       'status': 'used',
-                                       'username': 'mal@globus.org'}],
-                       'included': {'identity_providers': [
-                           {'alternative_names': ['Globus'],
-                            'domains': ['globus.org'],
-                            'id': 'ident-uuid',
-                            'name': 'Globus',
-                            'short_name': 'globus'}
-                       ]
-                       }},
-        'identity_id': 'mal-ident-1-uuid',
-        'idp_id': 'ident-uuid',
-        'last_name': 'Reynolds',
-        'username': 'mal@globus.org'
-    }
-
-
-def test_without_sessions(settings, user_details):
-    settings.SOCIAL_AUTH_GLOBUS_SESSIONS = False
-    goidc = GlobusOpenIdConnect()
-    assert goidc.auth_allowed(dict(), user_details) is True
-
-
 def test_without_allowed_groups(settings, user_details):
     settings.SOCIAL_AUTH_GLOBUS_ALLOWED_GROUPS = []
     goidc = GlobusOpenIdConnect()
@@ -188,7 +113,7 @@ def test_with_one_group(settings, mock_group_tokens, groups,
        {'name': 'Portal Users Group',
         'uuid': 'test-group-1-uuid'}
     ]
-    groups_client.return_value.get_user_groups.return_value = groups
+    groups_client.return_value.get_my_groups.return_value = groups
     goidc = GlobusOpenIdConnect()
     response = {'other_tokens': mock_group_tokens}
     assert goidc.auth_allowed(response, user_details) is True
@@ -200,7 +125,7 @@ def test_with_no_groups(settings, mock_group_tokens, user_details, groups_client
         'uuid': 'test-group-1-uuid'}
     ]
     # Globus returns no groups
-    groups_client.return_value.get_user_groups.return_value = []
+    groups_client.return_value.get_my_groups.return_value = MockResponseEnvelope()
     goidc = GlobusOpenIdConnect()
     response = {'other_tokens': mock_group_tokens}
     with pytest.raises(social_core.exceptions.AuthForbidden):
@@ -213,8 +138,8 @@ def test_with_wrong_identity(settings, mock_group_tokens, user_details, groups,
        {'name': 'Portal Users Group',
         'uuid': 'test-group-1-uuid'}
     ]
-    groups_client.return_value.get_user_groups.return_value = groups
-    get_json.return_value = groups
+    groups_client.return_value.get_my_groups.return_value = groups
+    # get_json.return_value = groups
     response = {'other_tokens': mock_group_tokens}
     goidc = GlobusOpenIdConnect()
     try:
@@ -224,38 +149,26 @@ def test_with_wrong_identity(settings, mock_group_tokens, user_details, groups,
         assert username == 'mal@anl.gov'
 
 
-def test_introspect(get_json):
+def test_groups_scope_not_configured(settings, user_details):
+    settings.SOCIAL_AUTH_GLOBUS_ALLOWED_GROUPS = [
+       {'name': 'Portal Users Group',
+        'uuid': 'test-group-1-uuid'}
+    ]
     goidc = GlobusOpenIdConnect()
-    goidc.introspect_token('mock_token')
-    get_json.assert_called_with(
-        'https://auth.globus.org/v2/oauth2/token/introspect',
-        auth=('mock_client_id', 'mock_client_secret'),
-        data={'token': 'mock_token', 'include': 'session_info,identities_set'},
-        method='POST'
-    )
+    with pytest.raises(ValueError):
+        goidc.auth_allowed({'other_tokens': {}}, user_details)
 
 
-def test_get_identities(get_json):
-    goidc = GlobusOpenIdConnect()
-    goidc.get_globus_identities('mock_token', ['id1, id2'])
-    get_json.assert_called_with(
-        'https://auth.globus.org/v2/api/identities',
-        headers={'Authorization': 'Bearer mock_token'},
-        method='GET',
-        params={'ids': 'id1, id2', 'include': 'identity_provider'}
-    )
-
-
-def test_standard_get_user_id(settings, user_details):
+def test_get_user_id(settings, user_details):
     response = {'sub': 'mal-ident-1-uuid'}
-    settings.SOCIAL_AUTH_GLOBUS_SESSIONS = False
     goidc = GlobusOpenIdConnect()
     user_id = goidc.get_user_id(user_details, response)
     assert user_id == 'mal-ident-1-uuid'
 
 
-def test_sessions_get_user_id(settings, user_details):
-    settings.SOCIAL_AUTH_GLOBUS_SESSIONS = True
+def test_denied_by_whitelist(settings, user_details, groups_client):
+    settings.SOCIAL_AUTH_GLOBUS_WHITELISTED_DOMAINS = ['foo.com', 'bar.com']
+    response = {'sub': 'mal-ident-1-uuid'}
     goidc = GlobusOpenIdConnect()
-    user_id = goidc.get_user_id(user_details, dict())
-    assert user_id == 'ident-uuid_mal-ident-1-uuid'
+    assert goidc.auth_allowed(response, user_details) is False
+    assert not groups_client.return_value.get_my_groups.called

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -162,7 +162,7 @@ def test_allowed_groups(client):
 @pytest.mark.django_db
 def test_allowed_groups_with_user(groups_client, user, client, mock_data, globus_response):
     globus_response.data = mock_data['get_user_groups']
-    groups_client.return_value.get_user_groups.return_value = mock_data['get_user_groups']
+    groups_client.return_value.get_my_groups.return_value = mock_data['get_user_groups']
     client.force_login(user)
     r = client.get(reverse('allowed-groups'))
     assert r.status_code == 200


### PR DESCRIPTION
I'm heading off on vacation as I author this, so it's in a slightly incomplete state. The highlights of this feature are adding the ability to easily set Globus Groups to restrict login. The admin configures `SOCIAL_AUTH_GLOBUS_ALLOWED_GROUPS`, then any user that attempts to login will have their groups checked. If any linked identity shows membership in _any_ of the groups configured, the user will be allowed to login to the portal. Otherwise, they are redirected to the `/allowed-groups` page.

These changes edit previous functionality based on Globus Sessions. There are some differences: 

* Session enforcement relies on having an active session. This is no longer needed, and active session information is no longer pulled
* prompt='login' is not longer set, due to the session requirement feature being removed
* Previously, the active session identity MUST have matched the exact identity added in the group. This has been relaxed to include the identity being any linked identity in any group.
* Custom user ids are no longer used for Django User objects. 
* The `SOCIAL_AUTH_GLOBUS_SESSIONS ` setting has been removed

There are still some items left to tick off:

- [ ] Remove Globus Session requirement -- Allow any linked identity in any group
- [ ] Allow configuring custom redirect for 'allowed-groups' url
- [ ] Update Unit tests
- [ ] Update Docs