### PR TITLE
fix: Remove un-used validate_token() function

### DIFF
--- a/globus_portal_framework/__init__.py
+++ b/globus_portal_framework/__init__.py
@@ -9,7 +9,7 @@ from globus_portal_framework.exc import (
 
 from globus_portal_framework.gclients import (
     load_auth_client, load_transfer_client, load_search_client,
-    load_globus_client, load_globus_access_token, validate_token,
+    load_globus_client, load_globus_access_token,
 )
 
 from globus_portal_framework.gsearch import (
@@ -35,7 +35,7 @@ __all__ = [
     'GroupsException', 'PortalAuthException',
 
     'load_auth_client', 'load_transfer_client', 'load_search_client',
-    'load_globus_client', 'load_globus_access_token', 'validate_token',
+    'load_globus_client', 'load_globus_access_token',
 
     'post_search', 'get_subject', 'get_index', 'get_template',
     'process_search_data', 'get_pagination',

--- a/globus_portal_framework/gclients.py
+++ b/globus_portal_framework/gclients.py
@@ -12,18 +12,6 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def validate_token(tok):
-    """Validate if the given token is active.
-
-    :returns: True if active
-    :raises globus_sdk.ExpiredGlobusToken: if token has expired."""
-    ac = globus_sdk.ConfidentialAppAuthClient(
-        settings.SOCIAL_AUTH_GLOBUS_KEY,
-        settings.SOCIAL_AUTH_GLOBUS_SECRET
-    )
-    return ac.oauth2_validate_token(tok).get('active', False)
-
-
 def revoke_globus_tokens(user):
     """
     Revoke all of a user's Globus tokens.

--- a/globus_portal_framework/gtransfer.py
+++ b/globus_portal_framework/gtransfer.py
@@ -9,7 +9,7 @@ from globus_portal_framework import (
     PreviewPermissionDenied, PreviewServerError, PreviewException,
     PreviewBinaryData, PreviewNotFound, ExpiredGlobusToken,
 
-    load_transfer_client, load_globus_access_token, validate_token
+    load_transfer_client, load_globus_access_token
 )
 
 log = logging.getLogger(__name__)
@@ -196,8 +196,6 @@ def preview(user, url, scope, chunk_size=512):
                 # formats), this should always work.
                 return '\n'.join(chunk.split('\n')[:-1])
             elif r.status_code == 401:
-                if not validate_token(token):
-                    raise ExpiredGlobusToken(token_name=scope)
                 raise PreviewPermissionDenied()
             elif r.status_code == 403:
                 raise PreviewPermissionDenied()


### PR DESCRIPTION
This function isn't used internally anywhere, and is leftover from older functionality. Its use was discussed, and it's very much something we want to discourage for pretty much all use-cases (It's much better to assume a token is active and deal with it being revoked).

This is an internal function, and more of a refactor, but labeling it a fix so it's noted in changenotes.