### PR TITLE
chore: Fix docs build sometimes failing due to bad version string

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 # Base requirements to build DGPF (We should make this use the top level reqs
 django<4.0.0
 globus_sdk<4.0.0
-social-auth-app-django<6.0.0>=3.0.0
+social-auth-app-django>=3.0.0,<6.0.0
 python-jose[cryptography]>=3.0.1
 packaging>=21.0
 


### PR DESCRIPTION
This failed once in automated builds recently, but only for py 3.10. I don't have an explanation for that, or why it didn't fail earlier. But it's an easy fix!