### PR TITLE
docs: Clarify v2, v3 template doc settings

### DIFF
--- a/docs/source/reference/migration.rst
+++ b/docs/source/reference/migration.rst
@@ -3,15 +3,20 @@
 Migration
 =========
 
-Migrating to v0.3.0
+This doc serves as a guide for upgrading to newer versions of Django Globus Portal Framework,
+and noting any breaking changes between versions developers should be aware of.
+
+Migrating to v0.5.x
 -------------------
 
-v0.3.0 introduces a fresh styling for the DGPF portal. You can migrate to the 
+v0.5.0 introduces a fresh styling for the DGPF portal. You can migrate to the
 new design by changing the following in your own `settings.py`.
 
 .. code-block:: python
 
-  # Changing base_template from v2 to v3
+  # Old templates
+  # BASE_TEMPLATES = 'globus-portal-framework/v2/'
+  # Newer templates
   BASE_TEMPLATES = 'globus-portal-framework/v3/'
 
 You can overwrite the existing templates for the v3 version by replacing the template

--- a/docs/source/reference/settings.rst
+++ b/docs/source/reference/settings.rst
@@ -70,6 +70,8 @@ Search Settings
 
 * ``SEARCH_INDEXES`` -- The main listing of search indexes in your portal
 
+  * See :ref:`search_settings_reference` for configuring an index.
+
 
 .. code-block::
 
@@ -88,11 +90,19 @@ Search Settings
 Templates
 ---------
 
+Baseline Globus Portal Framework templates are shipped for built-in views (see :ref:`custom_urls` and :ref:`custom_views` for more info),
+and templates (see :ref:`templates`) can be overrided and customized as needed.
+
 .. code-block::
 
-  # Setting for which Globus Portal Framework template set you should use.
-  # Mostly for backwards compatibility, but allows for a fully custom set of
-  # templates.
+  # Setting BASE_TEMPLATES changes two things:
+  #  * The template each view renders using ``globus_portal_framework.gsearch.get_template()``
+  #  * The base templates the ``index_template`` templatetag uses when doing template includes.
+  # Globus Portal Framework Supports the following:
+  #  * "" (Empty String) -- Old pre-v0.4.x templates. Deprecated and will be removed in v0.5.x
+  #  * "globus-portal-framework/v2/" -- Standard templates for version v0.4.x
+  #  * "globus-portal-framework/v3/" -- Standard templates for version v0.5.x
+  #  * "my/custom/template/pack" -- Fully custom base templates are also allowed
   BASE_TEMPLATES = 'globus-portal-framework/v2/'
 
   # General Template settings. Full example listed for reference, but only

--- a/docs/source/tutorial/portal/custom-urls.rst
+++ b/docs/source/tutorial/portal/custom-urls.rst
@@ -1,3 +1,5 @@
+.. _custom_urls:
+
 Customizing URLs
 ----------------
 

--- a/docs/source/tutorial/search/custom-views.rst
+++ b/docs/source/tutorial/search/custom-views.rst
@@ -1,3 +1,5 @@
+.. _custom_views:
+
 Custom Search Views
 ===================
 

--- a/docs/source/tutorial/search/templates.rst
+++ b/docs/source/tutorial/search/templates.rst
@@ -1,3 +1,6 @@
+.. _templates:
+
+
 Templates
 =========
 


### PR DESCRIPTION
Specify values in the settings reference, in addition to links to various other helpful docs. Clarify v2 templates are v0.4.x, and v3 templates are v0.5.x.