### PR TITLE
feat: Allow non-Globus users to access public search data

### DIFF
--- a/globus_portal_framework/exc.py
+++ b/globus_portal_framework/exc.py
@@ -29,6 +29,22 @@ class PortalAuthException(GlobusPortalException):
         self.index = ''
 
 
+class NonGlobusUserException(Exception):
+    """A Django user does not a have an association with Globus in the
+    social_django.models.UserSocialAuth Python Social Auth models.
+    This exception is raised when an attempt at accessing a Globus Client
+    for an authenticated Django user and GLOBUS_NON_USERS_ALLOWED_PUBLIC_ACCESS
+    is False.
+    """
+    def __init__(self, code='', message=''):
+        self.code = code or 'NonGlobusUserException'
+        self.message = (
+            message or 'Django user does not have a Globus User'
+            'association in social_django.models.UserSocialAuth.'
+        )
+        self.index = ''
+
+
 class GroupsException(GlobusPortalException):
     def __init__(self, code='', message=''):
         self.code = code or 'GroupsException'

--- a/globus_portal_framework/gclients.py
+++ b/globus_portal_framework/gclients.py
@@ -54,6 +54,9 @@ def is_globus_user(user):
 
     :returns: True if Globus association is present. False otherwise.
     """
+    if user.is_anonymous:
+        return False
+
     try:
         user.social_auth.get(provider="globus").extra_data
         return True

--- a/globus_portal_framework/gclients.py
+++ b/globus_portal_framework/gclients.py
@@ -9,6 +9,8 @@ import globus_sdk
 from globus_portal_framework import ExpiredGlobusToken, exc
 from globus_portal_framework.apps import get_setting
 
+import social_django
+
 import logging
 
 log = logging.getLogger(__name__)
@@ -46,6 +48,19 @@ def revoke_globus_tokens(user: "django.contrib.auth.models.User"):
              f'tokens for user {user}')
 
 
+def is_globus_user(user):
+    """
+    Check if a Django User has a Globus Association in Python Social Auth.
+
+    :returns: True if Globus association is present. False otherwise.
+    """
+    try:
+        user.social_auth.get(provider="globus").extra_data
+        return True
+    except social_django.models.UserSocialAuth.DoesNotExist:
+        return False
+
+
 def load_globus_access_token(user: "django.contrib.auth.models.User", token_name: str):
     """
     Load a globus user access token using a provided lookup by resource server.
@@ -65,23 +80,33 @@ def load_globus_access_token(user: "django.contrib.auth.models.User", token_name
     if not user:
         return None
     if user.is_authenticated:
-        tok_list = user.social_auth.get(provider='globus').extra_data
-        if token_name == 'auth.globus.org':
-            return tok_list['access_token']
-        if tok_list.get('other_tokens'):
-            service_tokens = {t['resource_server']: t
-                              for t in tok_list['other_tokens']}
+        if is_globus_user(user) is False:
+            if get_setting("GLOBUS_NON_USERS_ALLOWED_PUBLIC_ACCESS") is True:
+                log.info(
+                    f"User {user} is utilizing Globus Services as a non-globus user."
+                )
+                return None
+            else:
+                raise exc.NonGlobusUserException(
+                    f"User {user} does not have"
+                    " a Globus association in social_django.models.UserSocialAuth"
+                )
+        tok_list = user.social_auth.get(provider="globus").extra_data
+        if token_name == "auth.globus.org":
+            return tok_list["access_token"]
+        if tok_list.get("other_tokens"):
+            service_tokens = {t["resource_server"]: t for t in tok_list["other_tokens"]}
             service_token = service_tokens.get(token_name)
             if service_token:
-                exp_td = timedelta(seconds=service_token['expires_in'])
+                exp_td = timedelta(seconds=service_token["expires_in"])
                 if user.last_login + exp_td < timezone.now():
                     raise ExpiredGlobusToken(token_name=token_name)
-                return service_token['access_token']
+                return service_token["access_token"]
             else:
                 raise ValueError(
-                    f'Attempted to load {token_name} for user {user}, but no '
-                    f'tokens existed with the name {token_name}, only '
-                    f'{list(service_tokens.keys())}'
+                    f"Attempted to load {token_name} for user {user}, but no "
+                    f"tokens existed with the name {token_name}, only "
+                    f"{list(service_tokens.keys())}"
                 )
 
 

--- a/globus_portal_framework/settings.py
+++ b/globus_portal_framework/settings.py
@@ -86,6 +86,8 @@ SEARCH_MAX_PAGES = 10
 DEFAULT_QUERY = '*'
 DEFAULT_FILTER_MATCH = FILTER_MATCH_ALL
 
+GLOBUS_NON_USERS_ALLOWED_PUBLIC_ACCESS = True
+
 PREVIEW_DATA_SIZE = 2048
 
 ###############################################################################


### PR DESCRIPTION
These changes allow for non-Globus users to load public search clients to view public search data by default, with settings to allow for raising exceptions to handle special cases for non-globus users when they should be redirected somewhere else. This is handy if there are multiple indexes available, and it's desired for a private one to redirect to a Globus Login if desired (via middleware).