### PR TITLE
Fix Read-The-Docs documentation builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
   tools:
     python: "3.12"
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 python:
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
RTD requires a `.readthedocs.yml` file shown below. I was a bit surprised we didn't have this.