### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR introduces the following changes:

* Add a Dependabot config to auto-update GitHub action versions

Currently, the actions defined in two workflows are using old action versions, which are triggering deprecation warnings like this one ([recent example](https://github.com/globus/django-globus-portal-framework/actions/runs/11586089121)):

> ![image](https://github.com/user-attachments/assets/dbaea7a9-23d8-470b-9111-9c31a8a7fd38)

This can be addressed either by manually updating the versions (like changing `actions/checkout@v2` to `v4`), or by using Dependabot to watch for updates and submit update PRs.

If this PR is accepted, you can anticipate Dependabot immediately submitting a PR to update all of the action versions that need to be updated.