### PR TITLE
fix: Include missing copy-to-clipboard js

### DIFF
--- a/globus_portal_framework/static/js/copy-to-clipboard.js
+++ b/globus_portal_framework/static/js/copy-to-clipboard.js
@@ -1,0 +1,41 @@
+/*
+Expects a chuck of HTML like this:
+
+  <div class="collapse my-3" id="collapseExample">
+    <div class="card card-body">
+      <h5 class="text-center">Copy to Clipboard</h5>
+        <div id="copy-area" class="alert alert-info" role="alert">
+          <div class="row">
+            <div class="pt-2 col-md-11 text-center">
+              <a id="get-link-url" href="{{https_url}}">{{https_url}}</a>
+            </div>
+            <div class="col-md-1">
+              <button id="copy-button" class="btn btn-primary btn-lg"
+                      onclick="copyToClipboard('get-link-url', 'copy-area', '#copy-button');"
+                      data-toggle="tooltip" data-placement="top" title="Copied!">
+                <i class="fas fa-clipboard"></i>
+              </button>
+            </div>
+          </div>
+        </div>
+    </div>
+  </div>
+
+The widgetId or copy-area is just a place where this function can create a textArea
+to select and copy text. It is removed in an instant after the text is copied.
+*/
+
+function copyToClipboard(anchorId, widgetId, copyButtonId) {
+    var copyText = document.getElementById(anchorId).text;
+    var copyWidget = document.getElementById(widgetId);
+    var textArea = document.createElement('textarea');
+
+    textArea.value = copyText;
+    copyWidget.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    document.execCommand('copy');
+    copyWidget.removeChild(textArea);
+
+    $(copyButtonId).tooltip('show')
+}


### PR DESCRIPTION
Adding this as-is, since this should have existed for the v2 templates, but currently does not. For v3, we may want to do some edits. For instance: 

* `document.execCommand` is deprecated, there may be a better way to do this.
* The location, `js/copy-to-clipboard.js` doesn't differentiate from v2/v3 templates, and should be organized better
* This feature isn't all that user-friendly. More info below.

In order to use this feature, I noticed I needed these two fields: 

```
('https_url', lambda x: "http://example.com"),
('copy_to_clipboard_link', lambda x: "http://example.com"),
```

And I think we could do better for the v3 templates. Additionally, this feature isn't documented in the docs as far as I can tell. `https_url` and `copy_to_clipboard_link` otherwise are deep in the templates, which isn't obvious.

I don't think any of these criticisms should be addressed in this fix here, since this is simply fixing old behavior which should have been working (I'm still not sure why this snippet had been missing from the v2 templates!). But I wanted to make notes for future reference on how we could do things better.  