### PR TITLE
Fix result retrieval issues

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,5 @@
-# Base requirements to build DGPF (We should make this use the top level reqs
-django<4.0.0
-globus_sdk<4.0.0
-social-auth-app-django>=3.0.0,<6.0.0
-python-jose[cryptography]>=3.0.1
-packaging>=21.0
+# Base requirements to build DGPF
+-r ../requirements.txt
 
 # Other requirements
 sphinx_rtd_theme

--- a/docs/source/examples/built_in_fields.py
+++ b/docs/source/examples/built_in_fields.py
@@ -2,11 +2,6 @@ import os
 from urllib.parse import urlsplit, urlunsplit, urlencode
 
 
-def title(result):
-    """The title for this Globus Search subject"""
-    return result[0]["title"]
-
-
 def globus_app_link(result):
     """A Globus Webapp link for the transfer/sync button on the detail page"""
     url = result[0]["url"]

--- a/docs/source/tutorial/search/configuring-fields.rst
+++ b/docs/source/tutorial/search/configuring-fields.rst
@@ -45,7 +45,7 @@ search index by adding ``fields`` to your ``SEARCH_INDEXES``:
           "fields": [
               # Several syntaxes are available for retrieving a field
 
-              # Fetch the field by name
+              # Fetch the field by name, where the name in the search index matches the name used in the template
               "title",
 
               # Calls a function with your search record as a parameter
@@ -53,8 +53,9 @@ search index by adding ``fields`` to your ``SEARCH_INDEXES``:
               ("https_url", fields.https_url)
 
               ## Field retrieval/formatters can also be used with custom fields for custom templates
-              # Can fetch a field by alias
-              ("some_name_in_template", "original_collection_name"),
+              # Can fetch a field by alias. Works with flat or nested objects!
+              ("some_template_field", "original_name_in_search_index"),
+              ("another_template_field", "nested.path.to.field"),
           ],
       }
   }

--- a/docs/source/tutorial/search/configuring-fields.rst
+++ b/docs/source/tutorial/search/configuring-fields.rst
@@ -1,20 +1,19 @@
 .. _configuring_fields:
 
 
-Built-in Fields
-===============
+Passing result fields to templates
+====================================
+When rendering search results, it is sometimes useful to transform them into a more human-readable format before rendering to a template. (for example: parsing dates or generating links) It may also be useful to fetch "special" fields that will enable built in functionality.  For example the Django Globus Portal Framework includes built-in search result templates which will automatically
+render if a search result contains specific field names:
 
-Search Fields take raw search metadata from Globus Search and expose them for
-use by templates. Commonly, raw data from Globus Search needs a bit more processing
-before it can be viewed in templates. Examples include parsing dates or generating links
-to the Globus Webapp. 
+* ``title`` -- A title for a given subject, shown on the search results page and the detail page.
+* ``globus_app_link`` -- A link to the file on https://app.globus.org.
+* ``https_url`` -- A direct-download link to the file.
 
-The Django Globus Portal Framework includes some built-in templates which will automatically
-be rendered if given the right field names. Some of these include: 
+You can control what fields are presented to the Django templates, and how these fields are retrieved, using *fields*. The syntax allows you to specify how to find a field either by name, or a retrieval/formatter function.
 
-* Title -- A title for a given subject, shown on the search results page and the detail page.
-* Globus App Link -- A link to the file on https://app.globus.org.
-* HTTPS URL -- A direct-download link to the file.
+.. warning::
+   Search result templates will always receive two values: 'all' (the entire parsed JSON search result) and 'subject' (the subject ID for the index). Any other template variables must be explicitly specified in the ``fields`` configuration block. This means that you must explicitly specify how to find special template fields such as 'globus_app_link'.
 
 First, let's take a look at the metadata once more:
 
@@ -42,12 +41,20 @@ search index by adding ``fields`` to your ``SEARCH_INDEXES``:
   SEARCH_INDEXES = {
       "index-slug": {
           "uuid": "my-search-index-uuid",
-          ...  # Previous fields hidden for brevity
+          **options,  # Other options hidden for brevity
           "fields": [
+              # Several syntaxes are available for retrieving a field
+
+              # Fetch the field by name
+              "title",
+
               # Calls a function with your search record as a parameter
-              ("title", fields.title),
               ("globus_app_link", fields.globus_app_link),
               ("https_url", fields.https_url)
+
+              ## Field retrieval/formatters can also be used with custom fields for custom templates
+              # Can fetch a field by alias
+              ("some_name_in_template", "original_collection_name"),
           ],
       }
   }

--- a/globus_portal_framework/gsearch.py
+++ b/globus_portal_framework/gsearch.py
@@ -7,12 +7,12 @@ import math
 import collections
 import datetime
 import pathlib
-from packaging import version
-from urllib.parse import quote_plus, unquote
-import globus_sdk
+from urllib.parse import quote_plus, unquote_plus
+
 from django import template
 from django.utils.module_loading import import_string
 from django.conf import settings
+import globus_sdk
 
 from globus_portal_framework.apps import get_setting
 from globus_portal_framework import load_search_client, IndexNotFound, exc
@@ -433,13 +433,15 @@ def get_index(index):
 
 
 def get_subject(index, subject, user=None):
-    """Get a subject and run the result through the SEARCH_MAPPER defined
-    in settings.py. If no subject exists, return context with the 'subject'
-    and an 'error' message."""
+    """
+    Get a 'subject' and format the result consistent with the 'fields' defined
+    for this search index. If no subject exists, return context with the 'subject'
+    and an 'error' message.
+    """
     client = load_search_client(user)
     try:
         idata = get_index(index)
-        result = client.get_subject(idata['uuid'], unquote(subject))
+        result = client.get_subject(idata['uuid'], unquote_plus(subject))
         return process_search_data(idata.get('fields', {}), [result.data])[0]
     except globus_sdk.SearchAPIError:
         return {'subject': subject, 'error': 'No data was found for subject'}

--- a/globus_portal_framework/views/base.py
+++ b/globus_portal_framework/views/base.py
@@ -247,7 +247,7 @@ def search_debug_detail(request, index, subject):
     return render(request, gsearch.get_template(index, tvers), sub)
 
 
-def detail(request: HttpRequest, index: str, subject: str) ->  django.template.response.TemplateResponse:
+def detail(request: HttpRequest, index: str, subject: str) ->  django.http.HttpResponse:
     """
     Load a page for showing details for a single search result (subject). This view fetches
     the subject in the URL from Globus Search, and runs it through DGPF Fields (:ref:`configuring_fields`).

--- a/tests/test_gsearch.py
+++ b/tests/test_gsearch.py
@@ -192,6 +192,14 @@ def test_process_search_data_string_field(mock_data):
     data = process_search_data(['foo'], [gmeta])[0]
     assert data['foo'] == 'bar'
 
+def test_process_search_data_string_field_with_alias(mock_data):
+    gmeta = mock_data['search']['gmeta'][0]
+    gmeta['entries'][0]['content']['walrus'] = 'bar'
+    data = process_search_data(
+        [('foo', 'walrus')],  # The template field exists in data, but under a different name
+        [gmeta]
+    )[0]
+    assert data['foo'] == 'bar'
 
 def test_process_search_data_func_field(mock_data):
     gmeta = mock_data['search']['gmeta'][0]

--- a/tests/test_gsearch.py
+++ b/tests/test_gsearch.py
@@ -223,7 +223,19 @@ def test_process_search_data_string_field_with_alias(mock_data):
         'citation.missing.child',
         {'citation': {'title': 'two'}},
         None,
-    )
+    ),
+    (
+        # Return literal exact match over nested key
+        'citation.literal',
+        {'citation': {'literal': 'loses'}, 'citation.literal': 'wins'},
+        'wins',
+    ),
+    (
+        # If we match a literal key, it must be an exact match, or else we fall back to nested search
+        'citation.literal.most',
+        {'citation': {'literal': {'most': 'wins'} }, 'citation.literal': 'loses'},
+        'wins',
+    ),
 ])
 def test_process_search_data_string_field_with_dotted_path(path, search_content, expected):
     gmeta = { 'subject': 'test', 'entries': [{'content': search_content}] }


### PR DESCRIPTION
🦑 Happy to break this up into >1 PRs. It represents a set of tweaks I made to support a particular demo use case.

## Purpose
* Fix an issue where search result links could sometimes generate "subject not found" links for detail pages (due to mixing of not-inverse quote_plus / unquote operations)
  *   This manifested when a search index subject id name contained _spaces_
* Improve handling of `fields` in DGPF
  *  Explicitly document all three syntaxes that were supported previously, and the need to specify the special template fields explicitly in fields config
  * Fix mismatch between doc and project dependencies that prevented local doc build on Py3.13 (cgi module was removed, and old django versions used by docs tried to import it)
  * Add missing unit test for existing *(field name, alias)* mode
  * Allow (field_name, alias) mode to work with dotted path syntax (`item.citation.title`). Previously it only worked with top level keys. Now it can fetch a field that is inside a nested object
    *  I did not update the *get exact field name* syntax for dotted paths, on the grounds that template variables shouldn't have `.` in the name


## TODO 
* [x] On Monday I'll test this inside my own custom portal to verify functionality in a real world test case.
* [x] Verify that doc dep changes work in CI for old versions of python (5 warnings exist but they predate this PR- see comments below)