### PR TITLE
[draft] DGPF-extensible rendering of files based on public URL

### DIFF
--- a/globus_portal_framework/static/js/render-asset/main.js
+++ b/globus_portal_framework/static/js/render-asset/main.js
@@ -1,0 +1,85 @@
+import renderers, {renderLink} from './renderers.js'
+
+
+function _getURLOptions(url, token) {
+  /**
+   * Check the file to see if it is a valid target for rendering. For Globus https endpoints, this provides some
+   *    valuable information that can make something easier to render
+   *  @returns {{url, token, status, statusText, contentType, contentLength, required_scopes}}
+   */
+  const headers = new Headers({'X-Requested-With': 'XMLHttpRequest'});
+  if (token) {
+    headers.set('Authorization', `bearer ${token}`);
+  }
+  return fetch(url, {
+    method: 'HEAD',
+    headers: headers,
+  }).then((response) => {
+    const res = {
+      // Always provide these fields. Anything more is server-dependent.
+      url,
+      token,
+      'status': response.status,
+      'statusText': response.statusText
+    };
+
+    if (response.ok) {
+      res['ContentType'] = response.headers.get('content-type');
+      res['ContentLength'] = response.headers.get('content-length');
+    } // else if (response.status === 401) {
+    //   // FIXME: NOPE! Head response doesn't have a body. A second request would be needed for globus 401s and better to move that outside to a separate function since this isn't handling 401s anyway
+    //   //
+    //   // try {
+    //   //   // Globus HTTPS endpoints return JSON blobs describing what scopes are needed to see this file
+    //   //   // FIXME FIXME FIXME refactor because json is async method, this won't run as written
+    //   //   const body = response.json();
+    //   //   res['required_scopes'] = body?.authorization_parameters?.required_scopes;
+    //   // } catch (e) {
+    //   //   // Not every URL will return parser-friendly JSON; err response just won't provide help to fix problem
+    //   // }
+    // }
+    return res;
+  });
+}
+
+
+function doRender(target, {url, token, mode = 'auto'}) {
+  /**
+   * @param {Node | string} target The DOM node to use as rendered content root
+   * @param {string} url The full URL of the (usually public) asset to render
+   * @param {string} [mode] Optionally specify how to render the file. Usually 'auto' to guess by mimetype, or a
+   *  user-specified renderer (like PDB, plot.ly, or leaflet.js)
+   */
+  target.innerText = "";
+  _getURLOptions(url, token).then((urlOptions) => {
+    const {status, statusText} = urlOptions
+    if (status !== 200) {
+      // Asset cannot be retrieved, and therefore cannot be rendered
+      // TODO: Add a branch for 401. In the future, we might be able to use required_scopes for incremental reauth.
+      throw new Error(statusText);
+    }
+    return urlOptions;
+  }).then((urlOptions) => {
+    const {ContentType} = urlOptions;
+    let method;
+    if (mode && mode !== 'auto') {
+      method = renderers.get(mode);
+    } else {
+      method = renderers.get(ContentType);
+    }
+
+    if (!method) {
+      return renderLink(target, urlOptions, {message: `Unable to render files of type '${ContentType}'`});
+    }
+    return method(target, urlOptions);
+  }).catch((e) => {
+    console.error(e);
+    renderLink(target, {url}, {message: e.message});
+  });
+}
+
+
+// This is the main script block and it assumes a specific django template
+const render_options = JSON.parse(document.getElementById('render-options').textContent);
+const target = document.getElementById('render-target');
+doRender(target, render_options);

--- a/globus_portal_framework/static/js/render-asset/renderers.js
+++ b/globus_portal_framework/static/js/render-asset/renderers.js
@@ -201,19 +201,34 @@ function _urlToCode(target, urlOptions, renderOptions) {
     });
 }
 
+function _urlToTable(target, urlOptions, renderOption) {
+  try {
+    // _addCss("https://unpkg.com/tabulator-tables@6.3.1/dist/css/tabulator.min.css");
+    _addCss("https://unpkg.com/tabulator-tables@6.3.1/dist/css/tabulator_bootstrap4.min.css");
+    _addScript("https://unpkg.com/tabulator-tables@6.3.1/dist/js/tabulator.min.js");
+  } catch (e) {
+    return _urlToText(target, urlOptions);
+  }
 
-RENDERERS.add('application/pdf', _urlToObject)
+  return _fetchText(urlOptions).then((text) => {
+    const table = new Tabulator(target, {
+      data: text.trim(),
+      // Note: `text/tab-separated-values` may need custom code in tabulator to process
+      importFormat: "csv",
+      autoColumns: true,
+    });
+  });
+}
 
-// FIXME: Write these: advanced table views to show dependency-light builtin renderers
-// RENDERERS.add('text/csv');
-// RENDERERS.add('text/tab-separated-values');
 
+RENDERERS.add('text/csv', _urlToTable);  // tsv ,may
 RENDERERS.add('text/javascript', _urlToCode);
 RENDERERS.add('application/javascript', _urlToCode);
 RENDERERS.add('application/json', _urlToCode);
 // Incredibly leaky catchall; see https://mimetype.io/all-types
 RENDERERS.add('code', _urlToCode, (mt) => mt.startsWith('text/x-'));
 
+RENDERERS.add('application/pdf', _urlToObject)
 // Renderers are checked in order, so these are registered last as fallbacks
 RENDERERS.add('text', _urlToText, (mt) => mt.includes('text'));
 RENDERERS.add('image', _urlToObject, (mt) => mt.includes('image'));

--- a/globus_portal_framework/static/js/render-asset/renderers.js
+++ b/globus_portal_framework/static/js/render-asset/renderers.js
@@ -1,0 +1,174 @@
+"use strict";
+////////////////////////
+// Render data in various ways
+
+////////////////////////
+// Data retrieval
+function _sizeCheck({ContentLength} = fileData, maxSize = (10 * 2 ** 20)) {
+  // Throw an error if the file exceeds a size that can be safely handled
+  const size = (ContentLength ?? 0);
+  if (size > maxSize) {
+    throw new Error(`File is too large to preview`);
+  }
+  return true;
+}
+
+function _fetchAuthenticatedContent({url, token} = urlOptions, nBytes = null, rangeStart = 0) {
+  const headers = new Headers();
+  if (token) {
+    headers.set('Authorization', `bearer ${token}`);
+  }
+  if (nBytes) {
+    headers.set('Range', `bytes=${rangeStart}-${rangeStart + nBytes}`);
+  }
+  return fetch(url, {
+    method: 'GET',
+    headers: headers,
+  }).then((response) => {
+    if (response.ok) {
+      return response;
+    } else {
+      console.error(response);
+      throw new Error('Error retrieving file contents');
+    }
+  }).then((resp) => resp.blob());
+}
+
+function _fetchBinaryBlob(urlOptions) {
+  // Since binary blobs (like images) must be fetched all at once, there is a hard size limit
+  _sizeCheck(urlOptions);
+  return _fetchAuthenticatedContent(urlOptions);
+}
+
+function _fetchText(urlOptions, maxSize = (10 * 2 ** 20)) {
+  // Text files support partial rendering
+  const nBytes = (urlOptions.ContentLength > maxSize) ? maxSize : null;
+  return _fetchAuthenticatedContent(urlOptions, nBytes)
+    .then((blob) => blob.text());
+}
+
+
+///////////////
+// Utilities/ abstract methods
+class Registry {
+  constructor() {
+    // Matching items can be identified via exact match, or approximate (according to a bool test function)
+    this._name_registry = new Map();
+    this._match_registry = new Map();
+  }
+
+  add(name, item, test = null) {
+    if (this._name_registry.has(name)) {
+      console.warn(`User-defined function is overriding existing registry item '${name}'`);
+    }
+    this._name_registry.set(name, item);
+    if (test) {
+      this._match_registry.set(name, test);
+    }
+  }
+
+  get(name) {
+    // Find items by either literal match, or an approximate function
+    const by_name = this._name_registry.get(name);
+    if (by_name) {
+      return by_name;
+    }
+    for (const [key, test_func] of this._match_registry) {
+      if (test_func(name)) {
+        return this._name_registry.get(key);
+      }
+    }
+    return null;
+  }
+}
+
+const RENDERERS = new Registry();
+
+function _embedBlob(target, blob, {ContentType}) {
+  // Most rendering stuff is a thin wrapper for sticking something in an object tag
+  const el = document.createElement('object');
+  el.type = ContentType;
+  el.data = URL.createObjectURL(blob);
+  target.appendChild(el);
+}
+
+function _preformattedText(target, text) {
+
+}
+
+
+//////////////////
+// Renderers for specific data types
+// All renderers have a public call signature of f(targetNode, urlOptions, renderOptions) -> null, and any errors
+//  thrown by render function.will be shown to user as a message.
+function renderLink(target, {url}, {message}) {
+  /**
+   * Provide a direct download link for viewing a file later. Useful if we cannot render all or part of a file.
+   */
+  if (message) {
+    const p = document.createElement('p');
+    p.innerText = message;
+    target.appendChild(p);
+  }
+  const p = document.createElement('p');
+  const a = document.createElement('a');
+
+  // Adding a query param causes Globus HTTPS servers to send this as a download
+  //  https://docs.globus.org/globus-connect-server/v5/https-access-collections/#request_a_browser_download
+  const href = new URL(url);
+  href.searchParams.append('download', '1');
+
+  a.href = href.toString();
+  a.setAttribute('download', '');
+  a.innerText = 'Download the file directly';
+  p.appendChild(a);
+  target.appendChild(p);
+}
+
+
+function _urlToObject(target, urlOptions, renderOptions) {
+  // Generic object renderer (image, PDF, short movie clip)
+  return _fetchBinaryBlob(urlOptions)
+    .then((blob) => _embedBlob(target, blob, urlOptions));
+}
+
+function _urlToText(target, urlOptions, renderOptions={is_json: false}) {
+  // Displays text in a simple pre tag
+  const {is_json} = renderOptions;
+  return _fetchText(urlOptions)
+    .then((text) => {
+      if (is_json) {
+        // If "some text mode" fetched only part of the file, the JSON could be incomplete and fail to parse.
+        try {
+          return JSON.stringify(JSON.parse(text), null, 2);
+        } catch (e) {}
+      }
+      return text;
+    })
+    .then((text) => {
+      const pre = document.createElement('pre');
+      pre.innerText = text;
+      target.appendChild(pre);
+    });
+}
+
+RENDERERS.add('application/pdf', _urlToObject)
+RENDERERS.add('application/json',
+  (t, uo) => _urlToText(t, uo, {is_json: true}),
+  (mimetype) => mimetype.toLowerCase().includes('json')
+);
+
+// FIXME: Write these: advanced table views to show dependency-light builtin renderers
+// RENDERERS.add('text/csv');
+// RENDERERS.add('text/tab-separated-values');
+
+RENDERERS.add('text', _urlToText, (mt) => mt.includes('text'));
+RENDERERS.add('image', _urlToObject, (mt) => mt.includes('image'));
+
+// Used as part of other renderers, and for standalone error messaging
+export {renderLink, _urlToObject, _urlToText};
+export {_fetchBinaryBlob, _fetchText, _fetchAuthenticatedContent};
+
+// Exports a plugin registry which other code may choose to extend with custom functions / types
+// And lo, a thousand purists cried out and were suddenly silenced
+export default RENDERERS;

--- a/globus_portal_framework/templates/globus-portal-framework/v3/detail-render-asset.html
+++ b/globus_portal_framework/templates/globus-portal-framework/v3/detail-render-asset.html
@@ -4,8 +4,9 @@
 <html lang="en">
 <head>
     <title>Render asset</title>
+    <link rel="stylesheet" type="text/css" href="{% static 'bootstrap/css/bootstrap.min.css' %}" />
     {%block headextras%}
-      {#  You can add any custom code here, like custom render functions or stylesheets  #}
+      {#  You can add any custom code here, like custom render functions or stylesheets. #}
     {% endblock %}
 </head>
 <body>

--- a/globus_portal_framework/templates/globus-portal-framework/v3/detail-render-asset.html
+++ b/globus_portal_framework/templates/globus-portal-framework/v3/detail-render-asset.html
@@ -1,0 +1,17 @@
+{% load static %}
+{# May be rendered in an iframe, so we deliberately do not inherit base template #}
+<!doctype html>
+<html lang="en">
+<head>
+    <title>Render asset</title>
+    {%block headextras%}
+      {#  You can add any custom code here, like custom render functions or stylesheets  #}
+    {% endblock %}
+</head>
+<body>
+  <div id="render-target">Waiting...</div>
+
+  {{ render_options|json_script:"render-options" }}
+  <script type="module" src="{% static 'js/render-asset/main.js' %}" ></script>
+</body>
+</html>

--- a/globus_portal_framework/urls.py
+++ b/globus_portal_framework/urls.py
@@ -18,7 +18,7 @@ from django.contrib import admin
 from django.urls import path, include, register_converter
 from django.conf import settings
 from globus_portal_framework.views import (
-    search, index_selection, detail, detail_transfer, detail_preview, logout,
+    search, index_selection, detail, render_asset, detail_transfer, detail_preview, logout,
     allowed_groups, search_about,
 )
 from globus_portal_framework.apps import get_setting
@@ -101,6 +101,7 @@ search_urlpatterns = [
     path('<index:index>/detail-transfer/<subject>', detail_transfer,
          name='detail-transfer'),
     path('<index:index>/detail/<subject>/', detail, name='detail'),
+    path('<index:index>/render-asset/', render_asset, name='render_asset'),
     path('allowed-groups/', allowed_groups, name='allowed-groups'),
     # Globus search portal. Provides default url '/'.
     path('', index_selection, name='index-selection'),

--- a/globus_portal_framework/views/__init__.py
+++ b/globus_portal_framework/views/__init__.py
@@ -1,5 +1,5 @@
 from globus_portal_framework.views.base import (
-    search, detail, index_selection, allowed_groups, logout, search_about,
+    search, detail, render_asset, index_selection, allowed_groups, logout, search_about,
     search_debug, search_debug_detail,
 
     detail_transfer, detail_preview,
@@ -9,7 +9,7 @@ from globus_portal_framework.views.base import (
 
 __all__ = [
 
-    'search', 'detail', 'index_selection', 'allowed_groups', 'logout',
+    'search', 'detail',  'render_asset', 'index_selection', 'allowed_groups', 'logout',
     'search_about', 'search_debug', 'search_debug_detail',
 
     'detail_transfer', 'detail_preview',

--- a/globus_portal_framework/views/base.py
+++ b/globus_portal_framework/views/base.py
@@ -1,18 +1,20 @@
 import logging
 import copy
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 from collections import OrderedDict
 from json import dumps
 import globus_sdk
+
 import django
 from django.conf import settings
 from django.contrib import messages
 from django.shortcuts import render, redirect
 from django.urls import reverse
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, Http404
 from django.views.decorators.csrf import csrf_exempt
 from django.views.defaults import server_error, page_not_found
 from django.contrib.auth import logout as django_logout
+from django.core.exceptions import BadRequest
 
 from globus_portal_framework.apps import get_setting
 from globus_portal_framework import (
@@ -298,6 +300,47 @@ def detail(request: HttpRequest, index: str, subject: str) ->  django.template.r
     template = gsearch.get_template(index, tvers)
     return render(request, template, gsearch.get_subject(index, subject,
                                                          request.user))
+
+def render_asset(request: HttpRequest, index: str) -> HttpResponse:
+    """Render an HTML page representing a specific asset, suitable for embedding in an iframe"""
+    # TODO: implement authentication, validate against advertised collections for index
+    # Two ways to call view to specify what we want:
+    #   ?url=  - the url of a public asset somewhere on the web
+    #   ?collection=&path= - the globus collection information needed to show an asset privately - eventual!!!
+    tvers = gsearch.get_template_path('detail-render-asset.html', index=index)
+    template = gsearch.get_template(index, tvers)
+
+    page_options = {
+        # Placeholder until we add authorization handling later. For now, lock the page to public-only behaviors.
+        'is_authenticated': False,  # request.user.is_authenticated
+    }
+
+    render_options = {
+        # JS will auto-detect unless this is provided
+        'url': None, # set below
+        'token': None, # Placeholder for future functionality
+        'mode': request.GET.get('render_mode'),
+    }
+
+    if url:= request.GET.get('url'):
+        render_options['url'] = unquote(url)
+    elif (collection_id:= request.GET.get('collection_id')) and (path := request.GET.get('path')):
+        # TODO: in future, we'll want to check user auth status and whether user has pre-authorized access to these
+        #   collections / cross-check against a list of collection https tokens that are allowed to be leaked to the frontend
+        # to_show.update({'collection_id': collection_id, 'path': path})
+        raise BadRequest('This view only supports public URL requests. [Authenticated] guest collection access may be added in the future.')
+    else:
+        raise BadRequest('Must specify "url" to retrieve')
+        #raise BadRequest('Must specify either url or (collection_id, path)')
+
+    return render(
+        request,
+        template,
+        context={
+            **page_options,
+            "render_options": render_options,
+        }
+    )
 
 
 @csrf_exempt

--- a/globus_portal_framework/views/base.py
+++ b/globus_portal_framework/views/base.py
@@ -11,6 +11,7 @@ from django.contrib import messages
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, Http404
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.csrf import csrf_exempt
 from django.views.defaults import server_error, page_not_found
 from django.contrib.auth import logout as django_logout
@@ -300,7 +301,7 @@ def detail(request: HttpRequest, index: str, subject: str) ->  django.template.r
     template = gsearch.get_template(index, tvers)
     return render(request, template, gsearch.get_subject(index, subject,
                                                          request.user))
-
+@xframe_options_sameorigin
 def render_asset(request: HttpRequest, index: str) -> HttpResponse:
     """Render an HTML page representing a specific asset, suitable for embedding in an iframe"""
     # TODO: implement authentication, validate against advertised collections for index


### PR DESCRIPTION
🦑 Not a candidate for merge. Here to communicate work in progress, currently targeting my own needs. Very much a work in progress, so there are some big quirks!

## Purpose
Demonstrate a possible mechanism for rendering files within DGPF based on a public URL, with a pathway towards showing private files later.

## Current state
NOT a candidate for merge, but exposing to show one option if there is broader interest. UUID of test collection / search index available on request.

### Feature set
To see if the rendering is generic enough to be extensible, I've written crude renderers for image, text, source code highlighting, interactive data tables, PDF, and will write a custom page with interactive widgets around PDB files next.

![Screenshot 2025-02-19 at 12 59 19 AM](https://github.com/user-attachments/assets/7a06f742-1437-423c-9b13-f3634f5b45f1)


### Arch plan
This PR encompasses:
* A new route `/<index>/render?url=&collection_uuid=&path=` that can render either a public URL, or (eventually) auto-fetch user-approved bearer tokens for private file access (internally translating `collection_uuid`+ `path` into an https url for that collection)
  * All rendering can be done inside a sandboxed iframe, so badly implemented science widgets don't stomp on the DOM for everyone else
  * Multiple iframes can be rendered to handle multiple preview files, in custom template logic
* Provides a set of extensible renderers that decides what to show via content-type (may expose other choices later). A custom DGPF can add their own renderer with minor additional code.

The path to a more generic featureset would be:
* Allow each index to have a new configuration option specifying a) where to find the preview file, b) what to do with it, and c) a mandatory **whitelist** of collections that are allowed to work with authentication and send credentials to frontend
* A new django admin command that would check the collections whitelisted and compare against the DGPF login scopes, to help guide devs around pitfalls of improperly configured apps
* (someday) incremental reauth for collection access if we aren't able to predict the needed collections (if such a need arises)

## TODO
The following items are based on my own needs, and represent a potential way forward if this ever seemed useful for others.

1. Implement a more full-featured local demo to "kick the tires" around access control, security, extensibility, etc.
2. Review hooks for "resolve auth issues"
3. Possibly add CSP headers to DGPF for the render route to complement sandboxing, similar to [Joe's SSP feature](https://github.com/globus/static-search-portal/blob/ebd5fe39d6e474b08ab1a3b8312a000a98518eef/src/pages/_document.tsx#L11-L22). Allows more confident rendering of user-specified data due to XSS potential of this feature. 
4. There's some interest in, eg, plotly renderers for graphs.
5. Review current state around native ESM in browser. If the team is concerned about compat, parcel/vite/etc may be useful- but this comes with tradeoffs.
6. Consider configuration syntax for app around `collections` whitelist, how to specify preview field and render mode at collection level, etc. May revisit once improved field accessors are merged. (or other data access syntax)
7. Unit tests. Since this has so much interactive UI, give thought to how we'd keep this maintainable over time.