### PR TITLE
[minor] Fix "get link" detail navbar feature

### DIFF
--- a/globus_portal_framework/templates/globus-portal-framework/v2/detail-base.html
+++ b/globus_portal_framework/templates/globus-portal-framework/v2/detail-base.html
@@ -45,7 +45,7 @@
     {% endblock %}
     <div class="card-body">
       {% block copy_to_clipboard %}
-      {% include 'globus-portal-framework/v2/components/copy-to-clipboard.html' %}
+      {% include 'globus-portal-framework/v2/components/copy-to-clipboard.html' with copy_to_clipboard_link=https_url %}
       {% endblock %}
       <div class="container">
         {%block detail_body %}

--- a/globus_portal_framework/templates/globus-portal-framework/v3/detail-base.html
+++ b/globus_portal_framework/templates/globus-portal-framework/v3/detail-base.html
@@ -46,7 +46,7 @@
       {% endblock %}
       <div class="card-body">
         {% block copy_to_clipboard %}
-        {% include 'globus-portal-framework/v3/components/copy-to-clipboard.html' %}
+        {% include 'globus-portal-framework/v3/components/copy-to-clipboard.html' with copy_to_clipboard_link=https_url %}
         {% endblock %}
         <div class="container">
           {%block detail_body %}


### PR DESCRIPTION
# Purpose
The default templates have a feature that doesn't render as written. The copy button is only shown when `https_url` is defined, but the field is filled in based on a (never-defined) variable called `copy_to_clipboard_link`.

# Short term fix
This is the narrowest possible fix, just to avoid that moment of puzzlement for any new user.

Use the same variable to render the copy widget that was used to render the button.

Reduces tiny risk of breakage by changing the URL variable at point of usage, to match what the page already assumed it was called in _detail-nav.html_ `block detail_nav_get_link_button`.

Left the nominally reusable partial unchanged. (_copy-to-clipboard.html_).

# Long term
Most people are probably sharing datasets (not single files). The current implementation is not super aligned with user needs, which may explain why no one noticed. This is the smallest possible fix to restore stock functionality. 

# Example

Before
![Screenshot 2025-02-26 at 3 17 02 PM](https://github.com/user-attachments/assets/365e5be5-ff88-4e98-946d-b6310410189c)

After
![Screenshot 2025-02-26 at 3 16 41 PM](https://github.com/user-attachments/assets/39ec5437-03bd-4f15-b6d4-4b8418714cce)
