### PR TITLE
docs: Document template tags

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,7 @@ workflow.
    reference/urls
    reference/views
    reference/generic-views
+   reference/templatetags
    reference/local-settings
    reference/deployment
    reference/migration

--- a/docs/source/reference/templatetags.rst
+++ b/docs/source/reference/templatetags.rst
@@ -1,0 +1,22 @@
+.. _templatetags_reference:
+
+Template Tags
+=============
+
+
+index_template
+--------------
+
+.. automodule:: globus_portal_framework.templatetags.index_template
+   :members:
+   :member-order: bysource
+   :show-inheritance:
+
+
+is_active
+---------
+
+.. automodule:: globus_portal_framework.templatetags.is_active
+   :members:
+   :member-order: bysource
+   :show-inheritance:

--- a/globus_portal_framework/templatetags/index_template.py
+++ b/globus_portal_framework/templatetags/index_template.py
@@ -1,27 +1,39 @@
 """
-Selectively loads template overrides for a particular index.
+Selectively loads template overrides for a particular index. This is useful
+if you want to re-use base templates across multiple indices. You must override
+``template_override_dir`` in your index, then you can use ``{% index_template %}`` in
+your html templates.
 
 For example, an indexes defined as:
-SEARCH_INDEXES = {
-    'my_cool_index': {
-            'template_override_dir': 'my_index'
+
+.. code-block::
+
+    SEARCH_INDEXES = {
+        'my_cool_index': {
+                'template_override_dir': 'my_index'
+        }
+        'my_other_index': {
+                'template_override_dir': 'my_other_index'
+        }
     }
-    'my_other_index': {
-            'template_override_dir': 'my_other_index'
-    }
-}
 
 The app template dir can look like
 
-templates/
-    my_cool_index/
-        components/
-            detail-nav.html
-            search-results.html
-    my_other_index/
-        components/
-            search-results.html
-        search.html
+.. code-block::
+
+    templates/
+        my_cool_index/
+            globus-portal-framework/
+                v3/
+                    components/
+                        detail-nav.html
+                        search-results.html
+        my_other_index/
+            globus-portal-framework/
+                v3/
+                    components/
+                        search-results.html
+                    search.html
 
 In the example above, my_cool_index overrides search-results, so that template
 will be included in search.html instead of the default.
@@ -29,7 +41,25 @@ will be included in search.html instead of the default.
 In my_other_index, 'detail-nav.html' is not included, so the default will
 be used instead.
 
-Both examples here override 'search-results.html' to display custom results
+Both examples here override 'search-results.html' to display custom results.
+
+You specify index templates in the base template using the following:
+
+.. code-block::
+
+    # This specific file goes into your portal and overrides the existing DGPF template:
+    # "templates/globus-portal-framework/v3/search-base.html"
+    {% extends 'globus-portal-framework/v3/search-base.html' %}
+    {% load index_template %}
+
+    ... Lots of HTML code here ...
+
+    {% index_template 'globus-portal-framework/v3/components/search-results.html' as it_search_results %}
+    {% include it_search_results %}
+
+In the example above, ``search-base.html`` will attempt to load ``<index_name>/globus-portal-framework/v3/components/search-results.html``
+and will fall back on ``globus-portal-framework/v3/components/search-results.html`` if an index-specific template does
+not exist.
 """
 import re
 import logging

--- a/globus_portal_framework/templatetags/is_active.py
+++ b/globus_portal_framework/templatetags/is_active.py
@@ -1,3 +1,31 @@
+"""
+is_active is a template tag to check whether this is the currently
+active page, and will output ``active`` if the page is active, or
+the empty string ``""`` if the page is not active. It is useful working
+within bootstrap templates which use the ``active`` tag. An example is
+nav items:
+
+.. code-block::
+
+    {# templates/globus-portal-framework/v3/components/search-nav.html #}
+    {% load static is_active %}
+
+    <div class="subnav mt-auto bottom-border-0">
+    <ul class="nav nav-tabs nav-search-nav justify-content-center">
+        <li class="mt-auto">
+        <a class="btn btn-primary btn-lg border-0 squared {% is_active request 'search' index=globus_portal_framework.index %}" role="button"
+            href="{% url 'search' globus_portal_framework.index %}">Search</a>
+        </li>
+        <li class="mt-auto">
+        <a class="btn btn-primary btn-lg border-0 squared {% is_active request 'search-about' index=globus_portal_framework.index %}" role="button"
+            href="{% url 'search-about' globus_portal_framework.index %}">About</a>
+        </li>
+    </ul>
+    </div>
+
+In the example above, "Search" will become active when the user navigates to the search view, but will leave "About" inactive.
+
+"""
 import logging
 from django.template import Library
 from django.urls import resolve


### PR DESCRIPTION
These previously weren't documented, but merely existed within the DGPF templates. Docs have been updated so they show up nicely in the RTD