### PR TITLE
feat: Support new Globus Search query formats (query#1.0.0)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ workflow.
 
    reference/settings
    reference/settings-example
+   reference/index-configuration
    reference/urls
    reference/views
    reference/generic-views

--- a/docs/source/reference/index-configuration.rst
+++ b/docs/source/reference/index-configuration.rst
@@ -1,0 +1,81 @@
+.. _index_configuration:
+
+Index Configuration
+===================
+
+Configure your Globus Search index in your settings.py file with the keyword ``SEARCH_INDEXES``:
+
+.. code-block::python
+
+  SEARCH_INDEXES = {
+      'my-index-slug': {
+          'name': 'My Search Index',
+          'uuid': 'my-index-uuid',
+      }
+  }
+
+You *must* name your search index slug `my-index-slug`. The slug is used to determine
+the URL for your search index (default: ``https://mysite/my-index-slug/``). The `uuid` must
+also be set to tell the portal which search index to search.
+
+See :ref:`index_creation` for more information.
+
+Index Search Settings
+---------------------
+
+Most settings for each setting in SEARCH_INDEXES modify the *search* behavior when a
+user navigates to the search URL page, and many values here are simply passed through
+directly to Globus Search whenever a user queries an index.
+
+Three exceptions to this are ``q``, ``limit``, and ``offset``, which are determined
+by the search page instead of via configuration here.
+
+Some options below are only available with a particular Globus Search ``@version``.
+
+See the `Globus Search Documentation <https://docs.globus.org/api/search/reference/post_query/#gsearchrequest>`_
+for more information on select fields.
+
+===================== ==================
+Name                  Type       
+===================== ==================
+@version              String
+advanced              Boolean
+q_settings            Dict
+bypass_visible_to     Boolean
+filter_principal_sets List of Strings
+filters               Array
+facets                Array
+post_facet_filters    Array
+boosts                Array
+sort                  Array
+===================== ==================
+
+Index Portal Settings
+---------------------
+
+Some additional index settings drive portal behavior instead of search
+behavior. 
+
+.. note::
+    Developers may add their own fields here to take advantage of per-index
+    configuration. Additional custom fields are ignored by the portal. However,
+    Globus Portal Framework may add additional fields here which conflict
+    with your portal.
+
+===================== ====== ===========
+Name                  Type   Description    
+===================== ====== ===========
+uuid                  String The configured Globus Search index uuid to perform searches
+name                  String The human readable name the portal should use for this index
+===================== ====== ===========
+
+Referencing Indices in Views
+----------------------------
+
+You can reference these settings in your view with the following:
+
+.. code-block:: python
+
+    from globus_portal_framework.gsearch import get_index
+    index_data = get_index("my-index-slug")
+    print(f"My index {index_data['name']} has uuid {index_data['uuid']}")

--- a/globus_portal_framework/checks.py
+++ b/globus_portal_framework/checks.py
@@ -6,7 +6,7 @@ from django.conf import settings
 import globus_sdk
 
 from globus_portal_framework.constants import (
-    FILTER_TYPES
+    FILTER_TYPES, VALID_SEARCH_VERSIONS
 )
 
 log = logging.getLogger(__name__)
@@ -43,6 +43,23 @@ def check_search_indexes(app_configs, **kwargs):
                         obj=settings,
                         hint=f'Must be one of {tuple(FILTER_TYPES.keys())}'
                         ))
+    return errors
+
+
+@register()
+def check_search_index_version(app_configs, **kwargs):
+    errors = []
+    search_indexes = getattr(settings, 'SEARCH_INDEXES', {})
+    for index_name, idata in search_indexes.items():
+        if idata.get('@version') and idata['@version'] not in VALID_SEARCH_VERSIONS:
+            errors.append(Error(
+                'Bad Query version',
+                obj=settings,
+                hint=f'Index "{index_name}" has invalid @version "{idata["@version"]}". '
+                     f'Must be one of {VALID_SEARCH_VERSIONS}',
+                id='globus_portal_framework.settings.E006'
+                )
+            )
     return errors
 
 

--- a/globus_portal_framework/constants.py
+++ b/globus_portal_framework/constants.py
@@ -67,6 +67,8 @@ VALID_SEARCH_VERSIONS = [
     'query#1.0.0', '2017-09-01',
 ]
 
+DEFAULT_SEARCH_VERSION = '2017-09-01'
+
 BASE_TEMPLATES = 'globus-portal-framework/v2/'
 
 # drop_empty enforces backwards compatible facet handling for 0.3.x

--- a/globus_portal_framework/constants.py
+++ b/globus_portal_framework/constants.py
@@ -53,13 +53,18 @@ DATETIME_PARTIAL_FORMATS = {
 }
 
 VALID_SEARCH_KEYS = [
-    'q', 'limit', 'offset', 'facets', 'filters', 'boosts', 'sort',
-    'query_template', 'advanced', 'bypass_visible_to',
+    '@version', 'q', 'advanced', 'q_settings', 'limit', 'offset',
+    'bypass_visible_to', 'filter_principal_sets',
+    'filters', 'facets', 'post_facet_filters', 'boosts', 'sort',
 ]
 
 VALID_SEARCH_FACET_KEYS = [
     'name', 'type', 'field_name', 'size', 'histogram_range', 'date_interval',
-    'missing'
+    'missing',
+]
+
+VALID_SEARCH_VERSIONS = [
+    'query#1.0.0', '2017-09-01',
 ]
 
 BASE_TEMPLATES = 'globus-portal-framework/v2/'

--- a/globus_portal_framework/gsearch.py
+++ b/globus_portal_framework/gsearch.py
@@ -27,7 +27,7 @@ from globus_portal_framework.constants import (
 
     VALID_SEARCH_FACET_KEYS, VALID_SEARCH_KEYS,
 
-    DEFAULT_FACET_MODIFIERS,
+    DEFAULT_FACET_MODIFIERS, DEFAULT_SEARCH_VERSION
 )
 FILTER_RANGE_SEPARATOR = getattr(settings, 'FILTER_RANGE_SEPARATOR',
                                  FILTER_DEFAULT_RANGE_SEPARATOR)
@@ -86,7 +86,9 @@ def post_search(index, query, filters, user=None, page=1, search_kwargs=None):
     index_data = get_index(index)
     search_data = {k: index_data[k] for k in VALID_SEARCH_KEYS
                    if k in index_data}
+    version = search_data.get('@version', DEFAULT_SEARCH_VERSION)
     search_data.update({
+        '@version': version,
         'q': query,
         'facets': prepare_search_facets(index_data.get('facets', [])),
         'filters': filters,

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,6 +1,11 @@
 from uuid import uuid4
-from globus_portal_framework.constants import FILTER_TYPES
-from globus_portal_framework.checks import (check_search_indexes, check_allowed_groups)
+import pytest
+from globus_portal_framework.constants import FILTER_TYPES, VALID_SEARCH_VERSIONS
+from globus_portal_framework.checks import (
+    check_search_indexes,
+    check_search_index_version,
+    check_allowed_groups,
+)
 
 
 def test_valid_search_index(search_client):
@@ -14,6 +19,21 @@ def test_index_missing_uuid(settings, search_client, globus_response):
     r = check_search_indexes(None)
     assert len(r) == 1
     assert r[0].id == 'globus_portal_framework.settings.E001'
+
+
+
+@pytest.mark.parametrize("version", VALID_SEARCH_VERSIONS)
+def test_check_search_index_valid_versions(settings, version):
+    settings.SEARCH_INDEXES = {'myindex': {'uuid': 'foo', '@version': version}}
+    r = check_search_index_version(None)
+    assert len(r) == 0
+
+
+def test_check_search_index_version(settings):
+    settings.SEARCH_INDEXES = {'myindex': {'uuid': 'foo', '@version': 'bar'}}
+    r = check_search_index_version(None)
+    assert len(r) == 1
+    assert r[0].id == 'globus_portal_framework.settings.E006'
 
 
 def test_valid_filter_types_raise_no_errors(settings):


### PR DESCRIPTION
Add support for the new query format query#1.0.0. 

See more info for that on [Globus Discuss](https://groups.google.com/a/globus.org/g/discuss/c/IaRLEWbXVr0/m/ZCE5mkqhCgAJ), [Version History](https://docs.globus.org/api/search/changelog/#1_26_0_2024_09_27), and [Query Documentation](https://docs.globus.org/api/search/reference/post_query/#gsearchrequest).

Django Globus Portal Framework itself will allow specifying this version in the SEARCH_INDEXES fields, such as below: 

```
SEARCH_INDEXES = {
    'my_index': {
        'uuid': 'my_index_uuid',
        '@version': 'query#1.0.0',
    }
}
```

The `@version` field is optional and will default to the version that Globus Search uses. See the above documentation for when Globus Search will switch to the new version by default.

Please note, that the newer search version `query#1.0.0` changes the *behavior* of search results, but does not impose breaking changes on the search query structure for requests sent to Globus Search. DGPF developers should ensure that the new results returned by this query format is acceptable by the date the Globus Search service makes the switch.