### PR TITLE
docs: fix code block on index configuration docs page

### DIFF
--- a/docs/source/reference/index-configuration.rst
+++ b/docs/source/reference/index-configuration.rst
@@ -5,7 +5,7 @@ Index Configuration
 
 Configure your Globus Search index in your settings.py file with the keyword ``SEARCH_INDEXES``:
 
-.. code-block::python
+.. code-block:: python
 
   SEARCH_INDEXES = {
       'my-index-slug': {


### PR DESCRIPTION
The current docs page is broken here:

https://django-globus-portal-framework.readthedocs.io/en/latest/reference/index-configuration.html

This was missed in the last PR. 