### PR TITLE
fix: Compatibility for Globus SDK v4

### DIFF
--- a/.github/workflows/tests-sdk-v4.yml
+++ b/.github/workflows/tests-sdk-v4.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         pip install -r requirements.txt -r test-requirements.txt
-        pip install "globus-sdk>=4" --pre
+        pip install --pre "globus-sdk>3"
     - name: Lint with flake8
       run: |
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/globus_portal_framework/auth.py
+++ b/globus_portal_framework/auth.py
@@ -78,8 +78,11 @@ class GlobusOpenIdConnect(GlobusOpenIdConnectBase):
         groups a user belongs. The API is PUBLIC, and no special allowlists
         are needed to use it.
         """
-        groups_scopes = (GroupsScopes.all,
-                         GroupsScopes.view_my_groups_and_memberships)
+        # Groups changed slightly in v4, and we *should* be able to compare scope_string
+        # for the scopes below. But SDK v3 doesn't support that, so call str() on both
+        # scopes so the scope strings themselves can be compared below.
+        groups_scopes = (str(GroupsScopes.all),
+                         str(GroupsScopes.view_my_groups_and_memberships))
         groups_token = None
         for item in other_tokens:
             if item.get('scope') in groups_scopes:


### PR DESCRIPTION
Scopes changed slightly in the latest version, and comparing them directly to scope strings no longer works. Fix this in auth.py.